### PR TITLE
Wrong headers mentioned in the Docs

### DIFF
--- a/integrations/llms/aws-bedrock.mdx
+++ b/integrations/llms/aws-bedrock.mdx
@@ -184,7 +184,7 @@ If you do not want to add your AWS details to Portkey vault, you can also direct
 
 | Node SDK           | Python SDK               | REST Headers                    |
 | ------------------ | ------------------------ | ------------------------------- |
-| awsAccessKeyId     | aws\_access\_key\_id     | x-portkey-aws-session-token     |
+| awsAccessKeyId     | aws\_access\_key\_id     | x-portkey-aws-access-key-id     |
 | awsSecretAccessKey | aws\_secret\_access\_key | x-portkey-aws-secret-access-key |
 | awsRegion          | aws\_region              | x-portkey-aws-region            |
 | awsSessionToken    | aws\_session\_token      | x-portkey-aws-session-token     |
@@ -229,7 +229,7 @@ curl https://api.portkey.ai/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "x-portkey-api-key: $PORTKEY_API_KEY" \
   -H "x-portkey-provider: bedrock" \
-  -H "x-portkey-aws-session-token: $AWS_SESSION_TOKEN" \
+  -H "x-portkey-aws-access-key-id: $AWS_ACCESS_KEY_ID" \
   -H "x-portkey-aws-secret-access-key: $AWS_SECRET_ACCESS_KEY" \
   -H "x-portkey-aws-region: $AWS_REGION" \
   -H "x-portkey-aws-session-token: $AWS_TOKEN" \


### PR DESCRIPTION
there were wrong headers values mentioned for AWS Bedrock. 

Change
x-portkey-aws-session-token -> x-portkey-aws-access-key-id