### PR TITLE
Added virtualKey config to OpenAI client

### DIFF
--- a/integrations/llms/openai.mdx
+++ b/integrations/llms/openai.mdx
@@ -12,7 +12,7 @@ Provider Slug. `openai`
 To integrate the Portkey gateway with OpenAI,
 
 * Set the `baseURL` to the Portkey Gateway URL
-* Include Portkey-specific headers such as `provider`, `apiKey`and others.
+* Include Portkey-specific headers such as `provider`, `apiKey`, 'virtualKey' and others.
 
 Here's how to apply it to a **chat completion** request:
 <Tabs>
@@ -32,6 +32,7 @@ const openai = new OpenAI({
   defaultHeaders: createHeaders({
     provider: "openai",
     apiKey: "PORTKEY_API_KEY" // defaults to process.env["PORTKEY_API_KEY"]
+    // virtualKey: "VIRTUAL_KEY_VALUE" if you want provider key on gateway instead of client
   })
 });
 
@@ -67,6 +68,7 @@ client = OpenAI(
     default_headers=createHeaders(
         provider="openai",
         api_key="PORTKEY_API_KEY" # defaults to os.environ.get("PORTKEY_API_KEY")
+        # virtual_key="VIRTUAL_KEY_VALUE" if you want provider key on gateway instead of client
     )
 )
 

--- a/product/ai-gateway/virtual-keys.mdx
+++ b/product/ai-gateway/virtual-keys.mdx
@@ -95,6 +95,69 @@ completion = portkey.with_options(virtual_key="...").chat.completions.create(
   </Tab>
 </Tabs>
 
+### Using the OpenAI SDK
+
+Add the virtual key directly to the initialization configuration for the OpenAI client.
+<Tabs>
+  <Tab title="NodeJS">
+
+```js
+import OpenAI from "openai";
+import { PORTKEY_GATEWAY_URL, createHeaders } from 'portkey-ai'
+
+
+const openai = new OpenAI({
+  apiKey: '', // can be left blank
+  baseURL: PORTKEY_GATEWAY_URL,
+  defaultHeaders: createHeaders({
+    apiKey: "PORTKEY_API_KEY", // defaults to process.env["PORTKEY_API_KEY"]
+    virtualKey: "VIRTUAL_KEY" // Portkey supports a vault for your LLM Keys
+  })
+});
+```
+  </Tab>
+  <Tab title="Python">
+
+```py
+# Construct a client with a virtual key
+from openai import OpenAI
+from portkey_ai import PORTKEY_GATEWAY_URL, createHeaders
+
+client = OpenAI(
+  api_key="", # can be left blank
+  base_url=PORTKEY_GATEWAY_URL,
+  default_headers=createHeaders(
+    api_key="PORTKEY_API_KEY" # defaults to os.environ.get("PORTKEY_API_KEY")
+    virtual_key="VIRTUAL_KEY" # Portkey supports a vault for your LLM Keys
+  )
+)
+```
+  </Tab>
+</Tabs>
+
+Alternatively, you can override the virtual key during the completions call as follows:
+
+<Tabs>
+  <Tab title="NodeJS SDK">
+
+```js
+const chatCompletion = await portkey.chat.completions.create({
+    messages: [{ role: 'user', content: 'Say this is a test' }],
+    model: 'gpt-3.5-turbo',
+}, {virtualKey: "OVERRIDING_VIRTUAL_KEY"});
+```
+  </Tab>
+  <Tab title="Python SDK">
+
+```py
+completion = portkey.with_options(virtual_key="...").chat.completions.create(
+    messages = [{ "role": 'user', "content": 'Say this is a test' }],
+    model = 'gpt-3.5-turbo'
+)
+```
+  </Tab>
+</Tabs>
+
 ### Using alias with Azure virtual keys:
 
 ```js


### PR DESCRIPTION
Added example code showing how to configure a `virtualKey` when using the OpenAI sdk in noodejs or python.