### PR TITLE
Vertex AI Docs :- Provider Enum Correction 

### DIFF
--- a/integrations/llms/vertex-ai.mdx
+++ b/integrations/llms/vertex-ai.mdx
@@ -955,7 +955,7 @@ Vertex AI expects a `region`, a `project ID` and the `access token` in the reque
         apiKey: "PORTKEY_API_KEY",
         vertexProjectId: "sample-55646",
         vertexRegion: "us-central1",
-        provider:"vertex_ai",
+        provider:"vertex-ai",
         Authorization: "$GCLOUD AUTH PRINT-ACCESS-TOKEN"
     })
 
@@ -975,7 +975,7 @@ portkey = Portkey(
     api_key="PORTKEY_API_KEY",
     vertex_project_id="sample-55646",
     vertex_region="us-central1",
-    provider="vertex_ai",
+    provider="vertex-ai",
     Authorization="$GCLOUD AUTH PRINT-ACCESS-TOKEN"
 )
 


### PR DESCRIPTION
docs 

url :- https://portkey.ai/docs/integrations/llms/vertex-ai#python-sdk
```
const portkey = new Portkey({
    apiKey: "PORTKEY_API_KEY",
    vertexProjectId: "sample-55646",
    vertexRegion: "us-central1",
    provider:"vertex_ai",
    Authorization: "$GCLOUD AUTH PRINT-ACCESS-TOKEN"
})
```

here the the provider `vertex_ai` was giving me errors
``` 
{
    "success": true,
    "message": "Processed 0/1 records successfully",
    "results": [
        {
            "success": false,
            "error": "LLM processing failed: Error code: 400 - {'status': 'failure', 'message': 'Invalid provider passed'}"
        }
    ]
}
```

changing the provider from `vertex_ai` to `vertex-ai` resolved this issue.


Saw the same pattern for both `Python SDK ` and  `NodejsSDK`

in the `OpenAI Node SDK` and `Curl` the provider enum is `vertex-ai`


hope my PR is helpful for you guys and thanks for making  our  lifes easier.