### PR TITLE
feat: add Pi agent integration with Portkey

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -549,6 +549,7 @@
                     ]
                   },
                   "integrations/libraries/opencode",
+                  "integrations/libraries/pi-agent",
                   "integrations/libraries/openclaw",
                   "integrations/libraries/anthropic-computer-use",
                   "integrations/libraries/cline",

--- a/integrations/ai-apps.mdx
+++ b/integrations/ai-apps.mdx
@@ -31,6 +31,8 @@ title: "Overview"
 
   <Card title="Goose" href="/integrations/libraries/goose" />
 
+  <Card title="Pi Agent" href="/integrations/libraries/pi-agent" />
+
 
   <Card title="LibreChat" href="/integrations/libraries/librechat" />
 

--- a/integrations/libraries/pi-agent.mdx
+++ b/integrations/libraries/pi-agent.mdx
@@ -1,0 +1,173 @@
+---
+title: 'Pi Agent'
+description: 'Route Pi coding agent through Portkey for observability, cost tracking, and access to 200+ LLMs'
+---
+
+import AdvancedFeatures from '/snippets/portkey-advanced-features.mdx';
+
+[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) is a minimal, extensible terminal coding agent. It supports custom providers via `~/.pi/agent/models.json`, making it straightforward to route through Portkey's AI Gateway.
+
+With Portkey, you get full observability, cost tracking, budget controls, and access to any model from 200+ providers — all without changing how you use Pi.
+
+## Quick start
+
+<Steps>
+<Step title="Add a provider in Portkey">
+
+Go to [AI Providers](https://app.portkey.ai/ai-providers) → **Add Provider** → select your LLM provider (e.g., OpenAI, Anthropic, Google).
+
+Enter your provider API key and create a slug like `openai-prod` or `anthropic-prod`.
+
+<Frame>
+<img src="/images/product/model-catalog/create-provider-page.png" width="500"/>
+</Frame>
+</Step>
+
+<Step title="Get your Portkey API key">
+
+Go to [API Keys](https://app.portkey.ai/api-keys) → **Generate a new key**.
+
+</Step>
+
+<Step title="Configure Pi">
+
+Edit `~/.pi/agent/models.json` (create it if it doesn't exist):
+
+```json
+{
+  "providers": {
+    "portkey": {
+      "api": "openai-completions",
+      "baseUrl": "https://api.portkey.ai/v1",
+      "apiKey": "YOUR_PORTKEY_API_KEY",
+      "models": [
+        {
+          "id": "@openai-prod/gpt-4o",
+          "name": "GPT-4o via Portkey"
+        }
+      ]
+    }
+  }
+}
+```
+
+Replace:
+- `YOUR_PORTKEY_API_KEY` with your Portkey API key
+- `@openai-prod` with your provider slug
+- `gpt-4o` with the model you want to use
+
+The model `id` format is `@<provider-slug>/<model-name>` — this maps directly to a provider integration in your Portkey workspace.
+
+</Step>
+
+<Step title="Start Pi with Portkey">
+
+```bash
+pi --provider portkey --model gpt-4o
+```
+
+Or use the model selector inside Pi with <kbd>Ctrl</kbd>+<kbd>L</kbd> and pick your Portkey model.
+
+</Step>
+</Steps>
+
+All Pi requests now route through Portkey. Monitor usage, costs, and traces in the [Portkey Dashboard](https://app.portkey.ai/logs).
+
+## Add multiple models
+
+Add as many models as you need under the `models` array. Pi lets you cycle through them with <kbd>Ctrl</kbd>+<kbd>P</kbd>:
+
+```json
+{
+  "providers": {
+    "portkey": {
+      "api": "openai-completions",
+      "baseUrl": "https://api.portkey.ai/v1",
+      "apiKey": "YOUR_PORTKEY_API_KEY",
+      "models": [
+        {
+          "id": "@openai-prod/gpt-4o",
+          "name": "GPT-4o"
+        },
+        {
+          "id": "@anthropic-prod/claude-sonnet-4-20250514",
+          "name": "Claude Sonnet 4"
+        },
+        {
+          "id": "@gemini-prod/gemini-2.5-pro",
+          "name": "Gemini 2.5 Pro"
+        }
+      ]
+    }
+  }
+}
+```
+
+Each model `id` maps to a different provider integration in Portkey. This lets you switch between providers without managing separate API keys in Pi.
+
+## Use a Portkey Config
+
+For advanced routing — fallbacks, retries, caching, load balancing — create a [Portkey Config](/product/ai-gateway/configs) and reference it via a virtual key.
+
+<Steps>
+<Step title="Create a Config">
+
+Go to [Configs](https://app.portkey.ai/configs) → **Create Config**:
+
+```json
+{
+  "strategy": { "mode": "fallback" },
+  "targets": [
+    { "provider": "@openai-prod" },
+    { "provider": "@anthropic-prod" }
+  ]
+}
+```
+
+Save and copy the Config ID.
+
+</Step>
+
+<Step title="Create a virtual key with the Config">
+
+Go to [API Keys](https://app.portkey.ai/api-keys) → **Create Key** → attach your Config ID under **Advanced Settings**.
+
+Use this key as your `apiKey` in `models.json` and set the model `id` to any supported model name.
+
+</Step>
+</Steps>
+
+## Budget limits
+
+Set spending controls at the provider level to prevent runaway costs from long coding sessions:
+
+1. Go to [AI Providers](https://app.portkey.ai/ai-providers) → select your provider
+2. Click **Budget & Limits**
+3. Configure:
+   - **Cost limit**: Maximum spend (e.g., $100/month)
+   - **Token limit**: Maximum tokens (e.g., 5M tokens/week)
+   - **Rate limit**: Requests per minute
+
+<Frame>
+<img src="/images/product/model-catalog/budget-and-limits-page-model-catalog.png" width="500"/>
+</Frame>
+
+## Troubleshooting
+
+### Requests not appearing in Portkey logs
+
+**Cause:** Pi may not be using the configured provider.
+
+**Fix:**
+1. Verify `~/.pi/agent/models.json` is valid JSON — run `cat ~/.pi/agent/models.json` to check
+2. Start Pi with `--provider portkey` explicitly
+3. Confirm `baseUrl` is `https://api.portkey.ai/v1` (with `/v1`)
+4. Check that `apiKey` matches your Portkey API key
+
+### Model not found error
+
+**Cause:** The model `id` doesn't match a valid provider slug and model in your Portkey workspace.
+
+**Fix:** Go to [AI Providers](https://app.portkey.ai/ai-providers), confirm the provider slug, and verify the model name is supported by that provider.
+
+<AdvancedFeatures />

--- a/integrations/libraries/pi-agent.mdx
+++ b/integrations/libraries/pi-agent.mdx
@@ -103,39 +103,118 @@ Add as many models as you need under the `models` array. Pi lets you cycle throu
 }
 ```
 
-Each model `id` maps to a different provider integration in Portkey. This lets you switch between providers without managing separate API keys in Pi.
+Each model `id` maps to a different provider integration in Portkey. Switch providers without managing separate API keys in Pi.
 
-## Use a Portkey Config
+## Trace requests
 
-For advanced routing — fallbacks, retries, caching, load balancing — create a [Portkey Config](/product/ai-gateway/configs) and reference it via a virtual key.
+Add trace IDs to group and debug requests in the Portkey Dashboard. Create a [Portkey Config](/product/ai-gateway/configs) with metadata and attach it to a scoped API key:
 
 <Steps>
-<Step title="Create a Config">
+<Step title="Create a Config with metadata">
 
 Go to [Configs](https://app.portkey.ai/configs) → **Create Config**:
+
+```json
+{
+  "provider": "@openai-prod",
+  "metadata": {
+    "environment": "development",
+    "agent": "pi"
+  }
+}
+```
+
+Save and copy the Config ID.
+</Step>
+
+<Step title="Create a scoped API key with the Config">
+
+Go to [API Keys](https://app.portkey.ai/api-keys) → **Create Key** → attach your Config ID under **Advanced Settings**.
+
+</Step>
+
+<Step title="Use the scoped key in Pi">
+
+```json
+{
+  "providers": {
+    "portkey": {
+      "api": "openai-completions",
+      "baseUrl": "https://api.portkey.ai/v1",
+      "apiKey": "YOUR_SCOPED_PORTKEY_KEY",
+      "models": [
+        {
+          "id": "gpt-4o",
+          "name": "GPT-4o"
+        }
+      ]
+    }
+  }
+}
+```
+
+</Step>
+</Steps>
+
+Use trace metadata to:
+- Group all requests from a coding session
+- Debug issues by filtering logs by environment or agent
+- Track usage per project or task
+
+## Advanced configuration
+
+All advanced routing is configured through [Portkey Configs](/product/ai-gateway/configs), then attached to a scoped API key used as `apiKey` in `models.json`. Pi passes the key as a Bearer token — Portkey applies the routing logic server-side.
+
+### Fallbacks
+
+Route to backup providers when the primary fails. Create a config with fallback targets:
 
 ```json
 {
   "strategy": { "mode": "fallback" },
   "targets": [
     { "provider": "@openai-prod" },
-    { "provider": "@anthropic-prod" }
+    { "provider": "@anthropic-prod" },
+    { "provider": "@bedrock-prod" }
   ]
 }
 ```
 
-Save and copy the Config ID.
+### Load balancing
 
-</Step>
+Distribute requests across multiple API keys or providers:
 
-<Step title="Create a virtual key with the Config">
+```json
+{
+  "strategy": { "mode": "loadbalance" },
+  "targets": [
+    { "provider": "@openai-key-1", "weight": 0.5 },
+    { "provider": "@openai-key-2", "weight": 0.5 }
+  ]
+}
+```
 
-Go to [API Keys](https://app.portkey.ai/api-keys) → **Create Key** → attach your Config ID under **Advanced Settings**.
+### Caching
 
-Use this key as your `apiKey` in `models.json` and set the model `id` to any supported model name.
+Reduce costs and latency for repeated queries:
 
-</Step>
-</Steps>
+```json
+{
+  "provider": "@openai-prod",
+  "cache": { "mode": "simple" }
+}
+```
+
+### Retries
+
+Automatically retry failed requests:
+
+```json
+{
+  "provider": "@openai-prod",
+  "retry": { "attempts": 3, "on_status_codes": [429, 500, 502, 503] }
+}
+```
 
 ## Budget limits
 
@@ -151,6 +230,56 @@ Set spending controls at the provider level to prevent runaway costs from long c
 <Frame>
 <img src="/images/product/model-catalog/budget-and-limits-page-model-catalog.png" width="500"/>
 </Frame>
+
+Budget limits prevent runaway costs from agentic coding sessions.
+
+## Complete example
+
+Full `~/.pi/agent/models.json` with multiple providers and a scoped key that applies fallback + retry logic:
+
+```json
+{
+  "providers": {
+    "portkey": {
+      "api": "openai-completions",
+      "baseUrl": "https://api.portkey.ai/v1",
+      "apiKey": "YOUR_SCOPED_PORTKEY_KEY",
+      "models": [
+        {
+          "id": "gpt-4o",
+          "name": "GPT-4o (with fallback)"
+        },
+        {
+          "id": "@anthropic-prod/claude-sonnet-4-20250514",
+          "name": "Claude Sonnet 4"
+        },
+        {
+          "id": "@gemini-prod/gemini-2.5-pro",
+          "name": "Gemini 2.5 Pro"
+        }
+      ]
+    }
+  }
+}
+```
+
+Corresponding Portkey Config attached to the scoped key:
+
+```json
+{
+  "strategy": { "mode": "fallback" },
+  "targets": [
+    { "provider": "@openai-prod" },
+    { "provider": "@anthropic-prod" }
+  ],
+  "cache": { "mode": "simple" },
+  "retry": { "attempts": 3, "on_status_codes": [429, 500, 502, 503] },
+  "metadata": {
+    "agent": "pi",
+    "environment": "production"
+  }
+}
+```
 
 ## Troubleshooting
 
@@ -169,5 +298,14 @@ Set spending controls at the provider level to prevent runaway costs from long c
 **Cause:** The model `id` doesn't match a valid provider slug and model in your Portkey workspace.
 
 **Fix:** Go to [AI Providers](https://app.portkey.ai/ai-providers), confirm the provider slug, and verify the model name is supported by that provider.
+
+### Pi version issues
+
+**Cause:** Older versions of Pi may not support the `models.json` custom provider format.
+
+**Fix:** Update to the latest version:
+```bash
+npm update -g @mariozechner/pi-coding-agent
+```
 
 <AdvancedFeatures />

--- a/product/coding-agent.mdx
+++ b/product/coding-agent.mdx
@@ -39,6 +39,9 @@ Portkey is the gateway that sits between your team's coding agents and LLM provi
   <Card title="Roo Code" icon="code-branch" href="/integrations/libraries/roo-code">
     Drop-in Portkey integration via base URL override.
   </Card>
+  <Card title="Pi Agent" icon="terminal" href="/integrations/libraries/pi-agent">
+    Minimal extensible terminal coding agent. Route through Portkey via custom provider config.
+  </Card>
   <Card title="Goose, opencode & more" icon="grid" href="/integrations/libraries/opencode">
     Any OpenAI-compatible coding agent works with Portkey.
   </Card>


### PR DESCRIPTION
Adds documentation for routing Pi (pi-coding-agent) through Portkey's AI Gateway via the custom provider config in ~/.pi/agent/models.json. Covers quick start, multi-model setup, Portkey Configs, budget limits, and troubleshooting. Updates docs.json navigation.