### PR TITLE
docs: Anthropic service_tier → speed mapping

### DIFF
--- a/integrations/llms/anthropic.mdx
+++ b/integrations/llms/anthropic.mdx
@@ -716,6 +716,66 @@ response = portkey.chat.completions.create(
 The Files API is in beta and requires the `files-api-2025-04-14` beta header. Portkey sets this automatically for file endpoints. The Files API is not supported on Bedrock or Vertex AI.
 </Note>
 
+### Service Tier
+
+When routing Chat Completions requests to Anthropic, Portkey automatically translates OpenAI's `service_tier` parameter to Anthropic's native `speed` parameter:
+
+| `service_tier` | Anthropic `speed` |
+|---|---|
+| `auto` | `fast` |
+| `standard_only` | `standard` |
+| `default` | `standard` |
+| `fast` | `fast` |
+| `standard` | `standard` |
+| unknown value | omitted |
+
+<CodeGroup>
+```python Python icon="python"
+from portkey_ai import Portkey
+
+portkey = Portkey(
+    api_key="PORTKEY_API_KEY",
+    provider="@anthropic"
+)
+
+response = portkey.chat.completions.create(
+    model="claude-sonnet-4-5",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello!"}],
+    service_tier="auto"  # maps to speed: "fast" on Anthropic
+)
+```
+
+```js JavaScript icon="square-js"
+import Portkey from 'portkey-ai'
+
+const portkey = new Portkey({
+    apiKey: "PORTKEY_API_KEY",
+    provider: "@anthropic"
+})
+
+const response = await portkey.chat.completions.create({
+    model: "claude-sonnet-4-5",
+    max_tokens: 1024,
+    messages: [{ role: "user", content: "Hello!" }],
+    service_tier: "auto"  // maps to speed: "fast" on Anthropic
+})
+```
+
+```sh cURL icon="square-terminal"
+curl -X POST https://api.portkey.ai/v1/chat/completions \
+  -H "x-portkey-api-key: $PORTKEY_API_KEY" \
+  -H "x-portkey-provider: @anthropic" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-5",
+    "max_tokens": 1024,
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "service_tier": "auto"
+  }'
+```
+</CodeGroup>
+
 ### Beta Features
 
 Portkey supports Anthropic's beta features through headers. Pass the beta feature name as the value:


### PR DESCRIPTION
## Summary

- Adds a **Service Tier** section to the Anthropic integration docs documenting how `service_tier` (OpenAI-compatible) maps to Anthropic's native `speed` parameter
- Includes mapping table and Python / JS / cURL code examples

## Related

Gateway PR: https://github.com/Portkey-AI/gateway-enterprise-node/pull/1365

## Mapping

| `service_tier` | Anthropic `speed` |
|---|---|
| `auto` | `fast` |
| `standard_only` | `standard` |
| `default` | `standard` |
| `fast` | `fast` |
| `standard` | `standard` |
| unknown | omitted |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)