### PR TITLE
docs: add shared v1.7.5 changelog entry

### DIFF
--- a/changelog/frontend.mdx
+++ b/changelog/frontend.mdx
@@ -1,12 +1,25 @@
 ---
 title: "Frontend"
-sidebarTitle: "Frontend [1.7.4]"
+sidebarTitle: "Frontend [1.7.5]"
 rss: true
 ---
 
 <Card title="Schedule Call" href="https://portkey.sh/demo-21" icon="calendar" horizontal>
 Discuss how Portkey's AI Gateway can enhance your organization's AI infrastructure
 </Card>
+
+<Update label="1.7.5" description="2026-04-20">
+
+## v1.7.5
+
+---
+
+### Fixes and Improvements
+
+- Org-Admin permissions for Logs Management (`organisationAdminsViewLogs`, `organisationAdminsViewLogMetadata`)
+- Guardrail Management security settings with per-role view/write toggles and workspace-level override (`membersViewGuardrails`, `managersViewGuardrails`, `managersWriteGuardrails`, `workspace_overrides.security_settings.guardrails`)
+
+</Update>
 
 <Update label="1.7.4" description="2026-04-16">
 

--- a/changelog/frontend.mdx
+++ b/changelog/frontend.mdx
@@ -16,8 +16,8 @@ Discuss how Portkey's AI Gateway can enhance your organization's AI infrastructu
 
 ### Fixes and Improvements
 
-- Org-Admin permissions for Logs Management (`organisationAdminsViewLogs`, `organisationAdminsViewLogMetadata`)
-- Guardrail Management security settings with per-role view/write toggles and workspace-level override (`membersViewGuardrails`, `managersViewGuardrails`, `managersWriteGuardrails`, `workspace_overrides.security_settings.guardrails`)
+- Org-Admin permissions for Logs Management
+- Guardrail Management security settings with per-role view/write toggles and workspace-level override
 
 </Update>
 


### PR DESCRIPTION
## Summary
- Add a dedicated frontend changelog update PR for `v1.7.5` so docs feature PRs do not conflict on `changelog/frontend.mdx`.
- Include both shipped features in one shared update block:
  - Org-Admin logs permissions
  - Guardrail security settings and workspace override
- Bump `sidebarTitle` to `Frontend [1.7.5]`.

## Test plan
- [x] Verify `changelog/frontend.mdx` is the only changed file.
- [x] Confirm the new `v1.7.5` block appears above `v1.7.4`.
- [x] Confirm both feature bullets are present in the same update block.

## Merge order
Please merge this PR after the two docs content PRs:
- #874
- #875