### PR TITLE
docs: clarify Gemini thought fields compliance behavior

### DIFF
--- a/integrations/llms/gemini.mdx
+++ b/integrations/llms/gemini.mdx
@@ -1006,7 +1006,7 @@ curl --location 'https://api.portkey.ai/v1/chat/completions' \
 ## Thought Signatures (Tool Calling Verification)
 
 <Note>
-Set `x-portkey-strict-open-ai-compliance` to `false` to receive the `thought_signature` in the response. This header must be included in all requests when using thought signatures.
+Set `x-portkey-strict-open-ai-compliance` to `false` to receive Gemini-native thinking and thought fields (including `thought_signature`) in responses. These are not OpenAI-compatible response fields, so Portkey omits them when strict OpenAI compliance is enabled. This header must be included in all requests when using thought signatures.
 </Note>
 
 Google's Gemini 3 Pro model requires passing a `thought_signature` parameter in tool calling conversations for verifying the payload. This signature is returned by the model in the assistant's tool call response and must be included when continuing multi-turn conversations.


### PR DESCRIPTION
Explain that Gemini thinking/thought fields (including thought_signature) require strict OpenAI compliance to be disabled because those response fields are not OpenAI-compatible.

Made-with: Cursor