### PR TITLE
add docs for allow_subdomain flag

### DIFF
--- a/product/enterprise-offering/org-management/sso.mdx
+++ b/product/enterprise-offering/org-management/sso.mdx
@@ -135,3 +135,26 @@ Either of the following information is required:
 - Select `Save`.
 - Once everything is set up, please note the following details
     - Copy the `Federation metadata document URL` and paste it in Portkey Control Plane in `Admin Settings > Authentication Settings > SAML > Provider Metadata URL`
+
+---
+
+## Allowed Domains
+
+In `Admin Settings > Authentication Settings`, you can configure **Allowed Domains** to restrict which email domains are permitted to authenticate with your organization. You can add one or more domains (e.g., `example.com`) to control access.
+
+### Subdomain Support
+
+You can enable the **`allow_subdomains`** flag on a root domain to automatically allow authentication from **all subdomains** under that root domain.
+
+For example, if you add `example.com` as an allowed domain and enable `allow_subdomains`, users with emails from any subdomain like `dev.example.com`, `team.example.com`, or `us.example.com` will also be allowed to authenticate.
+
+<Warning>
+The `allow_subdomains` flag can only be enabled on **root domains**. If you attempt to enable it on a subdomain (e.g., `dev.example.com`), the operation will fail and return an error. Always set this flag on the root domain instead.
+</Warning>
+
+| Configuration | `allow_subdomains` | Allowed Emails |
+|---|---|---|
+| `example.com` | Disabled | Only `*@example.com` |
+| `example.com` | Enabled | `*@example.com`, `*@dev.example.com`, `*@team.example.com`, etc. |
+| `dev.example.com` | Enabled | **Error** — flag only works on root domains |
+| `dev.example.com` | Disabled | Only `*@dev.example.com` |


### PR DESCRIPTION
- An overview explaining that allowed domains can be configured in Admin Settings > Authentication Settings to restrict which email domains can authenticate
- A Subdomain Support subsection documenting the allow_subdomains flag — when enabled on a root domain, it permits authentication from all subdomains under it
- A Warning callout clearly stating that allow_subdomains only works on root domains and will throw an error if you try to enable it on a subdomain
- A reference table showing the scenarios: flag disabled (only root domain), flag enabled on root domain (all subdomains allowed), and flag enabled on a subdomain (error)