### PR TITLE
Updated Azure Foundry docs to include supported target UI formats

### DIFF
--- a/integrations/llms/azure-foundry.mdx
+++ b/integrations/llms/azure-foundry.mdx
@@ -207,6 +207,17 @@ You can Learn more about these [Azure Entra Resources here](https://learn.micros
 
 </Tabs>
 
+### Supported Target URI formats
+
+Use the **Target URI** from your Azure AI Foundry deployment details as the Azure Foundry URL in Portkey. Portkey supports the following endpoint formats:
+
+- **AI Services**: `https://your-resource-name.services.ai.azure.com/models`
+- **Project-scoped OpenAI v1**: `https://your-resource-name.services.ai.azure.com/api/projects/your-project-name/openai/v1`
+- **Managed**: `https://your-model-name.region.inference.ml.azure.com/score`
+- **Serverless**: `https://your-model-name.region.models.ai.azure.com`
+
+For project-scoped OpenAI deployments, enter the full `/api/projects/<project-name>/openai/v1` URL exactly as shown in Azure AI Foundry. Portkey appends the request route, such as `/chat/completions`, when sending traffic to the deployment.
+
 ## Adding Multiple Models to Your Azure AI Foundry Provider
 
 You can deploy multiple models through a single Azure AI Foundry provider by using Portkey's custom models feature.

--- a/integrations/llms/azure-foundry.mdx
+++ b/integrations/llms/azure-foundry.mdx
@@ -143,7 +143,6 @@ Portkey supports three authentication methods for Azure AI Foundry. For most use
     2. Click on the deployment to view details
     3. Copy the **API Key** from the authentication section
     4. Copy the **Target URI** - this is your endpoint URL
-       - For project-scoped OpenAI v1 deployments, this can be the full `https://your-resource-name.services.ai.azure.com/api/projects/your-project-name/openai/v1` URL.
     5. Note the **API Version** from your deployment URL
     6. **Azure Deployment Name** (Optional): Only required for Managed Services deployments
 

--- a/integrations/llms/azure-foundry.mdx
+++ b/integrations/llms/azure-foundry.mdx
@@ -163,6 +163,7 @@ Required parameters:
 - **Azure Managed ClientID**: Your managed client ID
 - **Azure Foundry URL**: The base endpoint URL for your deployment, formatted according to your deployment type:
   - For AI Services: `https://your-resource-name.services.ai.azure.com/models`
+  - For project-scoped OpenAI v1 deployments: `https://your-resource-name.services.ai.azure.com/api/projects/your-project-name/openai/v1`
   - For Managed: `https://your-model-name.region.inference.ml.azure.com/score`
   - For Serverless: `https://your-model-name.region.models.ai.azure.com`
 
@@ -188,6 +189,7 @@ Required parameters:
 - **Azure Entra Tenant ID**: Your tenant ID
 - **Azure Foundry URL**: The base endpoint URL for your deployment, formatted according to your deployment type:
   - For AI Services: `https://your-resource-name.services.ai.azure.com/models`
+  - For project-scoped OpenAI v1 deployments: `https://your-resource-name.services.ai.azure.com/api/projects/your-project-name/openai/v1`
   - For Managed: `https://your-model-name.region.inference.ml.azure.com/score`
   - For Serverless: `https://your-model-name.region.models.ai.azure.com`
 
@@ -206,15 +208,6 @@ You can Learn more about these [Azure Entra Resources here](https://learn.micros
   </Tab>
 
 </Tabs>
-
-### Supported Target URI formats
-
-Use the **Target URI** from your Azure AI Foundry deployment details as the Azure Foundry URL in Portkey. Portkey supports the following endpoint formats:
-
-- **AI Services**: `https://your-resource-name.services.ai.azure.com/models`
-- **Project-scoped OpenAI v1**: `https://your-resource-name.services.ai.azure.com/api/projects/your-project-name/openai/v1`
-- **Managed**: `https://your-model-name.region.inference.ml.azure.com/score`
-- **Serverless**: `https://your-model-name.region.models.ai.azure.com`
 
 For project-scoped OpenAI deployments, enter the full `/api/projects/<project-name>/openai/v1` URL exactly as shown in Azure AI Foundry. Portkey appends the request route, such as `/chat/completions`, when sending traffic to the deployment.
 

--- a/integrations/llms/azure-foundry.mdx
+++ b/integrations/llms/azure-foundry.mdx
@@ -143,6 +143,7 @@ Portkey supports three authentication methods for Azure AI Foundry. For most use
     2. Click on the deployment to view details
     3. Copy the **API Key** from the authentication section
     4. Copy the **Target URI** - this is your endpoint URL
+       - For project-scoped OpenAI v1 deployments, this can be the full `https://your-resource-name.services.ai.azure.com/api/projects/your-project-name/openai/v1` URL.
     5. Note the **API Version** from your deployment URL
     6. **Azure Deployment Name** (Optional): Only required for Managed Services deployments
 

--- a/integrations/llms/azure-foundry.mdx
+++ b/integrations/llms/azure-foundry.mdx
@@ -210,7 +210,7 @@ You can Learn more about these [Azure Entra Resources here](https://learn.micros
 
 </Tabs>
 
-For project-scoped OpenAI deployments, enter the full `/api/projects/<project-name>/openai/v1` URL exactly as shown in Azure AI Foundry. Portkey appends the request route, such as `/chat/completions`, when sending traffic to the deployment.
+For project-scoped OpenAI v1 deployments, enter the full URL ending with `/api/projects/<project-name>/openai/v1`, such as `https://your-resource-name.services.ai.azure.com/api/projects/your-project-name/openai/v1`, exactly as shown in Azure AI Foundry. Portkey appends the request route, such as `/chat/completions`, when sending traffic to the deployment.
 
 ## Adding Multiple Models to Your Azure AI Foundry Provider
 


### PR DESCRIPTION
## Summary
- Adds supported Target URI formats for Azure AI Foundry project-scoped OpenAI v1 endpoint.
- Clarifies that project-scoped `/api/projects/<project-name>/openai/v1` URLs should be entered as-is, with Portkey appending request routes like `/chat/completions`.
- This was added in the docs on the request of a customer in this pylon ticket: https://app.usepylon.com/support/issues/views/4305f6d4-1eeb-4039-92aa-1867128acd4f?issueNumber=4585&view=fs

## Test plan
- [x] Reviewed the Azure AI Foundry docs page locally.
- [ ] Verified the new guidance matches gateway behavior for `azureFoundryUrl` and appended request routes.