### PR TITLE
fix: set CONFIG_READER_PATH explicitly to point to the deployed albus…

### DIFF
--- a/self-hosting/airgapped/model-pricing.mdx
+++ b/self-hosting/airgapped/model-pricing.mdx
@@ -68,6 +68,7 @@ No request data is sent to Portkey. Only static JSON files are retrieved. See th
 | Variable | Value |
 | -------- | ----- |
 | `MODEL_CONFIGS_PROXY_FETCH_ENABLED` | `ON` |
+| `CONFIG_READER_PATH` | `<FE Loadbalancer>/albus/v2/utils/model-configs` |
 
 ### Backend
 
@@ -87,6 +88,7 @@ Use when no outbound internet is allowed.
 | Variable | Value |
 | -------- | ----- |
 | `MODEL_CONFIGS_PROXY_FETCH_ENABLED` | `ON` |
+| `CONFIG_READER_PATH` | `<FE Loadbalancer>/albus/v2/utils/model-configs` |
 
 ### Backend
 


### PR DESCRIPTION
… endpoint