### PR TITLE
docs: remove alert_threshold section from budget policies documentation

### DIFF
--- a/product/enterprise-offering/budget-policies.mdx
+++ b/product/enterprise-offering/budget-policies.mdx
@@ -130,21 +130,6 @@ The maximum usage limit that can be consumed before requests are blocked.
   - For `tokens` type: Value is in tokens
 - **Behaviour**: When the credit limit is reached, all matching requests will be blocked until the limit resets (if `periodic_reset` is configured)
 
-#### `alert_threshold` (optional)
-
-An optional threshold that triggers notifications before the credit limit is reached.
-
-- **Type**: Number (integer or float)
-- **Minimum value**: `1`
-- **Units**: 
-  - For `cost` type: Value is in USD (dollars)
-  - For `tokens` type: Value is in tokens
-- **Validation**: Must be less than `credit_limit` if provided
-- **Behaviour**: 
-  - When usage reaches this threshold, email notifications are sent to configured recipients
-  - The API key continues to function normally until the full `credit_limit` is reached
-  - Useful for proactive monitoring and budget management
-
 #### `periodic_reset` (optional)
 
 Configures automatic reset of the usage limit at regular intervals.
@@ -179,9 +164,8 @@ Override the timestamp of the next scheduled reset.
 1. **Conditions**: Each condition must have `key` and `value` fields.
 2. **Group By**: Each group must have a `key` field.
 3. **Valid Keys**: For both `conditions` and `group_by`, valid keys include `api_key`, `virtual_key`, `provider`, `config`, `prompt`, `model`, or any key starting with `metadata.`. `workspace_id` is supported only in `group_by`.
-4. **Alert Threshold**: Must be less than `credit_limit` if provided.
-5. **Workspace**: Workspace ID is required (can be provided via API key or request body).
-6. **Reset cadence**: `periodic_reset` and `periodic_reset_days` are mutually exclusive.
+4. **Workspace**: Workspace ID is required (can be provided via API key or request body).
+5. **Reset cadence**: `periodic_reset` and `periodic_reset_days` are mutually exclusive.
 
 ---
 


### PR DESCRIPTION
- Deleted the `alert_threshold` subsection, which included details on its type, validation, and behavior, to streamline the budget policies documentation.