### PR TITLE
docs: add alert thresholds section to budget policies documentation

### DIFF
--- a/product/enterprise-offering/budget-policies.mdx
+++ b/product/enterprise-offering/budget-policies.mdx
@@ -96,6 +96,10 @@ Usage limits policies allow you to set maximum usage (cost or tokens) that can b
 When a usage limit is exceeded, Portkey returns a **412 Precondition Failed** HTTP status code.
 </Note>
 
+### Alert thresholds: audit logs and notifications
+
+If you set an **`alert_threshold`**, Portkey records when usage crosses that threshold in **[audit logs](/product/enterprise-offering/audit-logs)**. Email and other proactive alerts for threshold crossings are **work in progress**; they are not sent today.
+
 ### Policy Types
 
 - **`cost`**: Limit based on total cost (in dollars)
@@ -129,6 +133,21 @@ The maximum usage limit that can be consumed before requests are blocked.
   - For `cost` type: Value is in USD (dollars)
   - For `tokens` type: Value is in tokens
 - **Behaviour**: When the credit limit is reached, all matching requests will be blocked until the limit resets (if `periodic_reset` is configured)
+
+#### `alert_threshold` (optional)
+
+An optional usage level (same units as `credit_limit`) before the limit is fully consumed.
+
+- **Type**: Number (integer or float)
+- **Minimum value**: `1`
+- **Units**:
+  - For `cost` type: Value is in USD (dollars)
+  - For `tokens` type: Value is in tokens
+- **Validation**: Must be less than `credit_limit` if provided
+- **Behaviour**:
+  - When usage reaches this threshold, an event is written to [audit logs](/product/enterprise-offering/audit-logs)
+  - Email and other proactive alerts for threshold crossings are **work in progress** and are not sent today
+  - Matching requests continue to be allowed until the full `credit_limit` is reached
 
 #### `periodic_reset` (optional)
 
@@ -164,8 +183,9 @@ Override the timestamp of the next scheduled reset.
 1. **Conditions**: Each condition must have `key` and `value` fields.
 2. **Group By**: Each group must have a `key` field.
 3. **Valid Keys**: For both `conditions` and `group_by`, valid keys include `api_key`, `virtual_key`, `provider`, `config`, `prompt`, `model`, or any key starting with `metadata.`. `workspace_id` is supported only in `group_by`.
-4. **Workspace**: Workspace ID is required (can be provided via API key or request body).
-5. **Reset cadence**: `periodic_reset` and `periodic_reset_days` are mutually exclusive.
+4. **Alert threshold**: Must be less than `credit_limit` if provided.
+5. **Workspace**: Workspace ID is required (can be provided via API key or request body).
+6. **Reset cadence**: `periodic_reset` and `periodic_reset_days` are mutually exclusive.
 
 ---
 


### PR DESCRIPTION
- Introduced an `alert_threshold` subsection detailing its purpose, type, validation, and behavior.
- Clarified that usage crossing the alert threshold will be recorded in audit logs, with proactive alerts currently in progress.