### PR TITLE
Document Portkey-registered MCP server usage in Responses API

### DIFF
--- a/product/ai-gateway/remote-mcp.mdx
+++ b/product/ai-gateway/remote-mcp.mdx
@@ -142,7 +142,7 @@ print(resp.output_text)
 
 Unlike the DeepWiki MCP server, most other MCP servers require authentication. The MCP tool in the Responses API gives you the ability to flexibly specify headers that should be included in any request made to a remote MCP server. These headers can be used to share API keys, oAuth access tokens, or any other authentication scheme the remote MCP server implements.
 
-The most common header used by remote MCP servers is the `Authorization` header. This is what passing this header looks like:
+you can pass additional headers in the headers object or the oauth token in the authorization key.
 
 Use Stripe MCP tool
 

--- a/product/ai-gateway/remote-mcp.mdx
+++ b/product/ai-gateway/remote-mcp.mdx
@@ -275,6 +275,52 @@ print(resp.output_text)
 To prevent the leakage of sensitive keys, the Responses API does not store the values of **any** string you provide in the `headers` object. These values will also not be visible in the Response object created. Additionally, because some remote MCP servers generate authenticated URLs, we also discard the _path_ portion of the `server_url` in our responses (i.e. `example.com/mcp` becomes `example.com`). Because of this, you must send the full path of the MCP `server_url` and any relevant `headers` in every Responses API creation request you make.
 
 
+### Using MCP Servers Registered on Portkey
+
+If you have MCP servers registered on Portkey's [MCP Gateway](/product/mcp-gateway), you can connect to them through the Responses API by passing the appropriate authentication in the tool definition.
+
+- **No-auth or header-based auth servers**: Pass your Portkey API key as `x-portkey-api-key` inside the `headers` object.
+- **OAuth-based servers**: Pass the OAuth access token using the `authorization` field on the tool.
+
+#### Header-based auth (or no auth)
+
+```json
+{
+  "model": "@OPENAI_PROVIDER/gpt-4.1",
+  "tools": [
+    {
+      "type": "mcp",
+      "server_label": "dmcp",
+      "server_description": "deepwiki mcp",
+      "server_url": "https://mcp.portkey.ai/deepwiki/mcp",
+      "headers": {
+        "x-portkey-api-key": "{{PORTKEY_API_KEY}}"
+      },
+      "require_approval": "never"
+    }
+  ],
+  "input": "what is portkey gateway"
+}
+```
+
+#### OAuth-based auth
+
+```json
+{
+  "model": "@OPENAI_PROVIDER/gpt-4.1",
+  "tools": [
+    {
+      "type": "mcp",
+      "server_label": "dmcp",
+      "server_description": "deepwiki mcp",
+      "server_url": "https://mcp.portkey.ai/deepwiki/mcp",
+      "authorization": "{{OAUTH_TOKEN}}",
+      "require_approval": "never"
+    }
+  ],
+  "input": "what is portkey gateway"
+}
+```
 
 
 


### PR DESCRIPTION
Adds a section under OpenAI Responses API Remote MCP Support explaining how to connect to MCP servers registered on Portkey's MCP Gateway, with examples for header-based auth (x-portkey-api-key) and OAuth-based auth.