### PR TITLE
Fill thinking models usage guidance

### DIFF
--- a/product/ai-gateway/multimodal-capabilities/thinking-mode.mdx
+++ b/product/ai-gateway/multimodal-capabilities/thinking-mode.mdx
@@ -505,6 +505,13 @@ This is especially important for streaming responses, where you'll need to speci
 
 Thinking models are particularly valuable in specific use cases:
 
+- **Complex problem solving:** Break down multi-step tasks such as math, planning, debugging, or technical analysis where the model needs to reason through intermediate steps before answering.
+- **High-stakes decision support:** Review contracts, policies, research, or operational runbooks where showing the reasoning path helps users audit the answer and catch missed assumptions.
+- **Long-context analysis:** Compare multiple documents, synthesize evidence, or trace dependencies across large inputs where the model benefits from allocating tokens to structured reasoning.
+- **Agentic workflows:** Power agents that need to plan tool calls, evaluate options, recover from errors, or explain why they chose a particular next step.
+- **Quality-sensitive generation:** Produce answers that need stronger consistency, constraint following, and self-checking, such as code review, architecture recommendations, or data analysis.
+
+For simple classification, extraction, summarization, or low-latency chat flows, a standard chat model is usually more cost-effective. Thinking mode adds reasoning tokens, so tune `budget_tokens` based on the complexity of the task and the amount of reasoning you want returned.
 
 
 ## FAQs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds practical guidance to the Thinking Mode page for when to use thinking models.
- Notes when standard chat models are a better fit and how `budget_tokens` affects cost/latency.

## Validation
- `npm exec -- mintlify broken-links` *(fails: existing repository-wide broken links in unrelated files; edited Thinking Mode page is not listed).*
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://portkeytalk.slack.com/archives/C063BRSLBK4/p1779352053093609?thread_ts=1779352053.093609&cid=C063BRSLBK4)

<div><a href="https://cursor.com/agents/bc-5730fde9-6b04-5093-a088-204a53222b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5730fde9-6b04-5093-a088-204a53222b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

