### PR TITLE
Fix Bedrock service_tier changelog entry

### DIFF
--- a/changelog/enterprise.mdx
+++ b/changelog/enterprise.mdx
@@ -55,8 +55,6 @@ Azure AI Foundry can use the native `/v1/responses` endpoint behind a flag, incl
 
 Bedrock provider requests can pass OpenAI-style `service_tier` where supported, with correct mapping and usage attribution for tiered Bedrock inference.
 
-[AWS Bedrock Documentation](/integrations/llms/bedrock/aws-bedrock)
-
 ### Realtime: Custom Host Routing for WebSockets
 
 Realtime WebSocket connections honor the configured custom host slug, matching HTTP routing. Previously routed to the provider default host regardless of the custom host setting.

--- a/changelog/enterprise.mdx
+++ b/changelog/enterprise.mdx
@@ -51,11 +51,11 @@ Azure AI Foundry can use the native `/v1/responses` endpoint behind a flag, incl
 
 [Azure AI Foundry Documentation](/integrations/llms/azure-foundry)
 
-### Responses API: `service_tier`
+### Amazon Bedrock Provider: `service_tier`
 
-`/v1/responses` passes through the `service_tier` parameter where the upstream provider supports it.
+Bedrock provider requests can pass OpenAI-style `service_tier` where supported, with correct mapping and usage attribution for tiered Bedrock inference.
 
-[Responses API Documentation](/api-reference/inference-api/responses/responses)
+[AWS Bedrock Documentation](/integrations/llms/bedrock/aws-bedrock)
 
 ### Realtime: Custom Host Routing for WebSockets
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Correct the Enterprise Gateway v2.9.0 changelog entry from Responses API `service_tier` support to Amazon Bedrock provider `service_tier` support.
- Remove the documentation link from the corrected changelog item.

## Verification
- Confirmed the old `### Responses API: \`service_tier\`` heading no longer exists in `changelog/enterprise.mdx`.
- Reviewed the final changelog diff for the requested documentation-link removal.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://portkeytalk.slack.com/archives/D0B22E9617T/p1778580127548569?thread_ts=1778580127.548569&cid=D0B22E9617T)

<div><a href="https://cursor.com/agents/bc-136daee7-903b-51fd-b051-28506cb4c66b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-136daee7-903b-51fd-b051-28506cb4c66b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

