### PR TITLE
docs(bedrock): update prompt caching supported models list

### DIFF
--- a/integrations/llms/bedrock/prompt-caching.mdx
+++ b/integrations/llms/bedrock/prompt-caching.mdx
@@ -12,13 +12,16 @@ Amazon Bedrock prompt caching is generally available with the following models:
 
 <Info>
 **Currently Supported Models:**
-- Claude 3.7 Sonnet
+- Claude Opus 4.6
+- Claude Opus 4.5
+- Claude Opus 4
+- Claude Sonnet 4.6
+- Claude Sonnet 4.5
+- Claude Haiku 4.5
 - Claude 3.5 Haiku
-- Amazon Nova Micro
-- Amazon Nova Lite
-- Amazon Nova Pro
-
-Customers who were given access to Claude 3.5 Sonnet v2 during the prompt caching preview will retain their access, but no additional customers will be granted access to prompt caching on the Claude 3.5 Sonnet v2 model.
+- Claude 3.7 Sonnet
+- Claude 3.5 Sonnet v2 (Preview)
+- Amazon Nova Micro, Lite, Pro (automatic caching)
 </Info>
 
 ## How Bedrock Prompt Caching Works
@@ -205,18 +208,27 @@ Supported TTL values are `"5m"` (5 minutes) and `"1h"` (1 hour). The TTL is forw
 
 Below is a detailed table of supported models, their minimum token requirements, maximum cache checkpoints, and fields that support caching:
 
-| Model | Model ID | Min tokens per checkpoint | Max checkpoints per request | Cacheable fields |
-|-------|----------|---------------------------|--------------------------|-----------------|
-| Claude 3.7 Sonnet | anthropic.claude-3-7-sonnet-20250219-v1:0 | 1,024 | 4 | system, messages, tools |
-| Claude 3.5 Haiku | anthropic.claude-3-5-haiku-20241022-v1:0 | 2,048 | 4 | system, messages, tools |
-| Amazon Nova Micro | amazon.nova-micro-v1:0 | 1,000 | 4 | system, messages |
-| Amazon Nova Lite | amazon.nova-lite-v1:0 | 1,000 | 4 | system, messages |
-| Amazon Nova Pro | amazon.nova-pro-v1:0 | 1,000 | 4 | system, messages |
+| Model | Model ID | Min tokens | Max checkpoints | Supported TTL | Cacheable fields |
+|-------|----------|------------|-----------------|---------------|------------------|
+| Claude Opus 4.6 | anthropic.claude-opus-4-6-v1 | 4,096 | 4 | 5 min | system, messages, tools |
+| Claude Opus 4.5 | anthropic.claude-opus-4-5-20251101-v1:0 | 4,096 | 4 | 5 min, 1 hour | system, messages, tools |
+| Claude Opus 4 | anthropic.claude-opus-4-20250514-v1:0 | 1,024 | 4 | 5 min | system, messages, tools |
+| Claude Sonnet 4.6 | anthropic.claude-sonnet-4-6 | 1,024 | 4 | 5 min | system, messages, tools |
+| Claude Sonnet 4.5 | anthropic.claude-sonnet-4-5-20250929-v1:0 | 4,096 | 4 | 5 min, 1 hour | system, messages, tools |
+| Claude Haiku 4.5 | anthropic.claude-haiku-4-5-20251001-v1:0 | 4,096 | 4 | 5 min, 1 hour | system, messages, tools |
+| Claude 3.5 Haiku | anthropic.claude-3-5-haiku-20241022-v1:0 | 2,048 | 4 | 5 min | system, messages, tools |
+| Claude 3.7 Sonnet | anthropic.claude-3-7-sonnet-20250219-v1:0 | 1,024 | 4 | 5 min | system, messages, tools |
+| Claude 3.5 Sonnet v2 | anthropic.claude-3-5-sonnet-20241022-v2:0 | 1,024 | 4 | 5 min | system, messages, tools |
+| Amazon Nova Micro | amazon.nova-micro-v1:0 | 1,000 | 4 | 5 min | system, messages |
+| Amazon Nova Lite | amazon.nova-lite-v1:0 | 1,000 | 4 | 5 min | system, messages |
+| Amazon Nova Pro | amazon.nova-pro-v1:0 | 1,000 | 4 | 5 min | system, messages |
 
 <Note>
-- The Amazon Nova models support a maximum of 32k tokens for prompt caching.
+- **Extended TTL:** Claude Opus 4.5, Claude Sonnet 4.5, and Claude Haiku 4.5 support both 5-minute and 1-hour TTL options.
+- The Amazon Nova models support a maximum of 20K tokens for prompt caching. Prompt caching is primarily for text prompts. They also support automatic prompt caching for all text prompts without explicit configuration.
 - For Claude models, tools caching is fully supported.
 - Tools caching is not supported for Amazon Nova models.
+- Claude 3.5 Sonnet v2 is in Preview status.
 </Note>
 
 ## Understanding Token Counts and Pricing


### PR DESCRIPTION
Sync Bedrock prompt caching documentation with the latest AWS official docs - add Claude Opus 4/4.5/4.6, Sonnet 4.5/4.6, Haiku 4.5, and Claude 3.5 Sonnet v2; add TTL column; fix Nova max cache tokens (32K → 20K).


Pylon: https://app.usepylon.com/support/issues/views/following?issueNumber=5898

Source: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html


Amazon Nova Models:
https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-lite.html
https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-micro.html
https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-pro.html