### PR TITLE
release gateway v2.14.0 and v2.14.1

### DIFF
--- a/changelog/enterprise.mdx
+++ b/changelog/enterprise.mdx
@@ -1,12 +1,62 @@
 ---
 title: "Enterprise Gateway"
-sidebarTitle: "Enterprise Gateway [2.13.0]"
+sidebarTitle: "Enterprise Gateway [2.14.1]"
 rss: true
 ---
 
 <Card title="Schedule Call" href="https://portkey.sh/demo-21" icon="calendar" horizontal>
 Discuss how Portkey's AI Gateway can enhance your organization's AI infrastructure
 </Card>
+
+<Update label="2.14.1" description="2026-07-10">
+
+## v2.14.1
+---
+
+### Prisma AIRS: Agentic Client Support
+
+New `scan_scope` and `strip_scaffolding` parameters for the Palo Alto Networks Prisma AIRS guardrail. `scan_scope` controls which messages are scanned (`last_message`, `last_user_message`, `user_messages`, or `all_messages`), while `strip_scaffolding` removes known agent-harness wrappers (e.g., `<system-reminder>` blocks, MCP tool instructions) before scanning — reducing false positives for agentic clients like Claude Code, Cursor, and Cline. Tool result content is preserved for injection detection. Fully backwards-compatible with existing configurations.
+
+[Prisma AIRS Documentation](/integrations/guardrails/palo-alto-panw-prisma)
+
+</Update>
+
+<Update label="2.14.0" description="2026-07-09">
+
+## v2.14.0
+---
+
+### Unified Models Endpoint
+
+`GET /v1/models` now routes through the gateway's provider-backed model listing handler. The endpoint calls the upstream provider, applies response transforms and returns the normalized model list — replacing the previous pass-through delegation.
+
+[Models API Documentation](/api-reference/inference-api/models/models)
+
+### Guardrails: Soft Deny (HTTP 200)
+
+New `soft_deny_200` flag on guardrail checks. When enabled, a guardrail denial returns HTTP 200 with the error message formatted as a chat completion response instead of the standard HTTP 446. This keeps sessions alive for clients that treat 4xx status codes as fatal errors (e.g., Claude Code).
+
+[Guardrails Documentation](/product/guardrails)
+
+### Provider Updates
+
+- **Anthropic**: Multidimensional pricing — cost attribution now differentiates batch (50% discount), fast (speed-priority on Opus models), and standard pricing tiers
+- **xAI**: Server-side tool invocation costs (file search, web search) are now tracked for cost attribution
+- **Hugging Face**: Fixed model name sanitation
+
+[Providers Documentation](/integrations/llms)
+
+### Fixes and Improvements
+
+- **Guardrails**: Async output guardrails now correctly execute when they are the only output hook configured
+- **Proxy**: Provider auth credentials are no longer overwritten by client-forwarded headers on proxy routes
+- **MCP Gateway**: Fixed config cache TTL unit mismatch and stale cache invalidation on server recreation
+- **Configs**: Added limit enforcement on config targets
+- **Caching**: Expired keys are cached slightly longer to reduce control plane network calls during transient expiry
+- **Memory**: Improved memory usage and reduced OOM risk under high load
+- Updated dependencies to patch security vulnerabilities
+
+</Update>
 
 <Update label="2.13.0" description="2026-06-30">
 

--- a/changelog/enterprise.mdx
+++ b/changelog/enterprise.mdx
@@ -51,7 +51,11 @@ New `soft_deny_200` flag on guardrail checks. When enabled, a guardrail denial r
 - **Guardrails**: Async output guardrails now correctly execute when they are the only output hook configured
 - **Proxy**: Provider auth credentials are no longer overwritten by client-forwarded headers on proxy routes
 - **MCP Gateway**: Fixed config cache TTL unit mismatch and stale cache invalidation on server recreation
-- **Configs**: Added limit enforcement on config targets
+- **Configs**: Config target fan-out is now capped to prevent egress amplification and resource exhaustion from deeply nested configs. Default limits: **100** root-level targets (1,000 for conditional strategy), **50** nested targets per root target
+
+<Warning>
+Configs exceeding the new target limits will be rejected at request time. If your deployment uses configs with more targets, override the defaults with the `MAX_ROOT_CONFIG_TARGETS`, `MAX_NESTED_CONFIG_TARGETS`, or `MAX_CONDITIONAL_ROOT_CONFIG_TARGETS` environment variables before upgrading.
+</Warning>
 - **Caching**: Expired keys are cached slightly longer to reduce control plane network calls during transient expiry
 - **Memory**: Improved memory usage and reduced OOM risk under high load
 - Updated dependencies to patch security vulnerabilities

--- a/integrations/guardrails/palo-alto-panw-prisma.mdx
+++ b/integrations/guardrails/palo-alto-panw-prisma.mdx
@@ -35,6 +35,8 @@ Before integrating with Portkey:
   - **Profile Name** (required): Enter the security profile name from your Prisma AIRS configuration
   - **AI Model**: Specify the AI model identifier (optional)
   - **App User**: Specify the application user context (optional)
+  - **Scan Scope**: Controls which messages are scanned (optional, defaults to `last_message`)
+  - **Strip Scaffolding**: Removes known agent-harness wrappers before scanning (optional, defaults to `false`)
 * Set any `actions` you want on your check, and create the Guardrail!
 
 
@@ -44,7 +46,35 @@ Before integrating with Portkey:
 
 | Check Name | Description | Parameters | Supported Hooks |
 |------------|-------------|------------|-----------------|
-| PANW Prisma AIRS Guardrail | Blocks prompt/response when Palo Alto Networks Prisma AI Runtime Security returns action=block | `Profile Name` (string, required), `AI Model` (string), `App User` (string) | `beforeRequestHook`, `afterRequestHook` |
+| PANW Prisma AIRS Guardrail | Blocks prompt/response when Palo Alto Networks Prisma AI Runtime Security returns action=block | `Profile Name` (string, required), `AI Model` (string), `App User` (string), `Scan Scope` (enum), `Strip Scaffolding` (boolean) | `beforeRequestHook`, `afterRequestHook` |
+
+### Parameter Details
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `Profile Name` | string | — | Security profile name from Prisma AIRS (required) |
+| `AI Model` | string | — | AI model identifier for context-aware detection |
+| `App User` | string | — | Application user context |
+| `Scan Scope` | enum | `last_message` | Which messages to scan: `last_message`, `last_user_message`, `user_messages`, `all_messages` |
+| `Strip Scaffolding` | boolean | `false` | Remove known agent-harness wrappers (e.g., `<system-reminder>` blocks, MCP tool instructions) before scanning |
+
+### Recommended Configuration for Agentic Clients
+
+When using Portkey with agentic clients like Claude Code, Cursor, or Cline, these clients often inject scaffolding into messages (system reminders, MCP tool instructions, suggestion mode markers) that can trigger false positives in security scans. Use `scan_scope` and `strip_scaffolding` to reduce noise while preserving detection of real threats:
+
+```json
+{
+  "scan_scope": "last_user_message",
+  "strip_scaffolding": true
+}
+```
+
+- **`scan_scope: "last_user_message"`** — skips non-user messages (e.g., system hooks, assistant scaffolding) and scans only the last user message
+- **`strip_scaffolding: true`** — strips known agent-harness wrappers before sending text to AIRS
+
+<Note>
+Tool result content (`tool_result`) is always preserved and scanned regardless of `strip_scaffolding`, since tool results are untrusted external input where indirect prompt injection can occur.
+</Note>
 
 ### 4. Add Guardrail ID to a Config and Make Your Request
 


### PR DESCRIPTION
## Summary

- Add changelog entries for Enterprise Gateway v2.14.0 (2026-07-09) and v2.14.1 (2026-07-10) to `changelog/enterprise.mdx`
- Update Prisma AIRS guardrail documentation with new `scan_scope` and `strip_scaffolding` parameters introduced in v2.14.1
- Bump `sidebarTitle` from `[2.13.0]` to `[2.14.1]`

## Changes

### Changelog — v2.14.0

| Category | Items |
|----------|-------|
| **Highlights** | Unified Models Endpoint (`GET /v1/models` provider-backed handler), Guardrails Soft Deny (`soft_deny_200` flag — HTTP 200 instead of 446) |
| **Provider Updates** | Anthropic multidimensional pricing (batch/fast/standard), xAI server-side tool cost attribution, Hugging Face model name fix |
| **Fixes** | Async output guardrails execution, proxy auth credential overwrite, MCP config cache TTL & invalidation, config targets limit, cache resilience, OOM improvements, dependency patches |

### Changelog — v2.14.1

| Category | Items |
|----------|-------|
| **Highlight** | Prisma AIRS `scan_scope` and `strip_scaffolding` for agentic clients (Claude Code, Cursor, Cline) |

### Documentation update — Prisma AIRS

Updated `integrations/guardrails/palo-alto-panw-prisma.mdx`:
- Added `Scan Scope` and `Strip Scaffolding` to parameter list and summary table
- Added "Parameter Details" table with all 5 parameters
- Added "Recommended Configuration for Agentic Clients" section

## Test plan

- [ ] Verify changelog renders correctly on docs site (v2.14.1 above v2.14.0 above v2.13.0)
- [ ] Verify sidebar shows `Enterprise Gateway [2.14.1]`
- [ ] Verify all doc links resolve (`/api-reference/inference-api/models/models`, `/product/guardrails`, `/integrations/llms`, `/integrations/guardrails/palo-alto-panw-prisma`)
- [ ] Verify Prisma AIRS page renders the new parameter table and agentic config section