### PR TITLE
Update Helm chart reference in Gateway Registration documentation

### DIFF
--- a/self-hosting/hybrid-deployments/gateway-registration.mdx
+++ b/self-hosting/hybrid-deployments/gateway-registration.mdx
@@ -82,7 +82,7 @@ The overview page shows:
 
 ## Deployment Steps
 
-For Helm chart deployment details, refer to the [values.yaml reference](https://github.com/Portkey-AI/helm/blob/airs_gw/charts/portkey-gateway/values.yaml).
+For Helm chart deployment details, refer to the [values.yaml reference](https://github.com/Portkey-AI/airs-gw-helm/blob/main/charts/airs-gw/README.md).
 
 ---
 


### PR DESCRIPTION
- Changed the link for Helm chart deployment details to point to the updated README in the new repository structure.