### PR TITLE
chore:add drop and default params to gw config object

### DIFF
--- a/api-reference/inference-api/config-object.mdx
+++ b/api-reference/inference-api/config-object.mdx
@@ -389,6 +389,15 @@ The `config` object is used to configure API interactions with various providers
     "override_params": {
       "type": "object"
     },
+    "default_params": {
+      "type": "object"
+    },
+    "drop_params": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "api_key": {
       "type": "string"
     },
@@ -590,6 +599,12 @@ The `config` object is used to configure API interactions with various providers
     },
     {
       "required": ["passthrough"]
+    },
+    {
+      "required": ["default_params"]
+    },
+    {
+      "required": ["drop_params"]
     }
   ],
   "additionalProperties": false


### PR DESCRIPTION
Adding default_params and drop_params to gateway config object as this has been overlooked after resolveParams pipeline creation
