### PR TITLE
chore: replace all demo/calendly links with Palo Alto Networks AI Gat…

### DIFF
--- a/api-reference/admin-api/introduction.mdx
+++ b/api-reference/admin-api/introduction.mdx
@@ -216,6 +216,6 @@ For developers looking to integrate with the Admin API, we provide a complete Op
 
 If you need help setting up or using the Admin API, our team is ready to assist:
 
-<Card title="Book a Support Call" icon="calendar" href="https://portkey.sh/demo-1">
+<Card title="Book a Support Call" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
   Schedule time with our team to get personalized help with the Admin API
 </Card>

--- a/api-reference/sdk/list.mdx
+++ b/api-reference/sdk/list.mdx
@@ -47,7 +47,7 @@ You can use Portkey with many OpenAI-compatible and community SDKs. Here are som
 ## FAQs
 <AccordionGroup>
 <Accordion title="Missing your language? Need help integrating Portkey?">
-[Email us](mailto:support@portkey.ai) or [book a demo](https://portkey.sh/demo-15) with our team!
+[Book a demo](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action) with our team!
 </Accordion>
 <Accordion title="Can I use Portkey with my favorite OpenAI SDK?">
 Yes! Any OpenAI-compatible SDK or HTTP client can be used with Portkey by simply pointing to the Portkey API endpoint and using your Portkey API key.

--- a/api-reference/sdk/node.mdx
+++ b/api-reference/sdk/node.mdx
@@ -148,7 +148,7 @@ const chatCompletion = await portkey.chat.completions.create(
 
 ## Troubleshooting & Support
 
-- Having trouble? [Email support](mailto:support@portkey.ai) or [book a demo](https://portkey.sh/demo-15) with our team.
+- Having trouble? [Book a demo](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action) with our team.
 - [View the SDK on GitHub](https://github.com/Portkey-AI/portkey-node-sdk)
 - [Report issues or request features](https://github.com/Portkey-AI/portkey-node-sdk/issues)
 

--- a/api-reference/sdk/python.mdx
+++ b/api-reference/sdk/python.mdx
@@ -183,7 +183,7 @@ completion = portkey.with_options(
 
 ## Troubleshooting & Support
 
-- Having trouble? [Email support](mailto:support@portkey.ai) or [book a demo](https://portkey.sh/demo-15) with our team.
+- Having trouble? [Book a demo](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action) with our team.
 - [View the SDK on GitHub](https://github.com/Portkey-AI/portkey-python-sdk)
 - [Report issues or request features](https://github.com/Portkey-AI/portkey-python-sdk/issues)
 

--- a/changelog/2024/nov.mdx
+++ b/changelog/2024/nov.mdx
@@ -27,7 +27,7 @@ As AI infrastructure becomes increasingly critical for enterprises, technology l
 <Frame caption="Akshay Darbari, Director of Platform Engineering at Premera Blue Cross">
 <img width="700" src="/images/changelog/premera-testimonial.jpeg" />
 </Frame>
-When Premera Blue Cross’ Director of Platform Engineering needed an AI Gateway, they chose Portkey. Why? Because traditional API gateways [weren’t built](https://portkey.ai/blog/ai-gateway-vs-api-gateway) for AI-first companies. Are you in the same boat? Schedule an [expert consultation here](https://calendly.com/portkey-ai/quick-consult).
+When Premera Blue Cross’ Director of Platform Engineering needed an AI Gateway, they chose Portkey. Why? Because traditional API gateways [weren’t built](https://portkey.ai/blog/ai-gateway-vs-api-gateway) for AI-first companies. Are you in the same boat? Schedule an [expert consultation here](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 
 ---
 

--- a/changelog/2025/september.mdx
+++ b/changelog/2025/september.mdx
@@ -43,7 +43,7 @@ Key benefits include:
 - Complete visibility into agent-tool interactions
 - Access controls and usage limits by team
 
-👉 To try out the beta, [send us an email](mailto:support@portkey.ai) or [book a demo](https://portkey.sh/sept-email).
+👉 To try out the beta, [book a demo](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action).
 
 ### Unified token counting endpoint
 

--- a/changelog/backend.mdx
+++ b/changelog/backend.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Backend [1.19.0]"
 rss: true
 ---
 
-<Card title="Schedule Call" href="https://portkey.sh/demo-21" icon="calendar" horizontal>
+<Card title="Schedule Call" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action" icon="calendar" horizontal>
 Discuss how Portkey's AI Gateway can enhance your organization's AI infrastructure
 </Card>
 

--- a/changelog/enterprise.mdx
+++ b/changelog/enterprise.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Enterprise Gateway [2.13.0]"
 rss: true
 ---
 
-<Card title="Schedule Call" href="https://portkey.sh/demo-21" icon="calendar" horizontal>
+<Card title="Schedule Call" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action" icon="calendar" horizontal>
 Discuss how Portkey's AI Gateway can enhance your organization's AI infrastructure
 </Card>
 

--- a/changelog/frontend.mdx
+++ b/changelog/frontend.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Frontend [1.9.3]"
 rss: true
 ---
 
-<Card title="Schedule Call" href="https://portkey.sh/demo-21" icon="calendar" horizontal>
+<Card title="Schedule Call" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action" icon="calendar" horizontal>
 Discuss how Portkey's AI Gateway can enhance your organization's AI infrastructure
 </Card>
 

--- a/changelog/helm-chart.mdx
+++ b/changelog/helm-chart.mdx
@@ -3,6 +3,6 @@ title: "Helm Chart"
 url: "https://github.com/Portkey-AI/helm/tags"
 ---
 
-<Card title="Schedule Call" href="https://portkey.sh/demo-21" icon="calendar" horizontal>
+<Card title="Schedule Call" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action" icon="calendar" horizontal>
 Discuss how Portkey's AI Gateway can enhance your organization's AI infrastructure
 </Card>

--- a/changelog/node-sdk-changelog.mdx
+++ b/changelog/node-sdk-changelog.mdx
@@ -3,6 +3,6 @@ title: "Node.js"
 url: "https://github.com/Portkey-AI/portkey-node-sdk/tags"
 ---
 
-<Card title="Schedule Call" href="https://portkey.sh/demo-21" icon="calendar" horizontal>
+<Card title="Schedule Call" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action" icon="calendar" horizontal>
 Discuss how Portkey can enhance your organization's AI infrastructure
 </Card>

--- a/changelog/python-sdk-changelog.mdx
+++ b/changelog/python-sdk-changelog.mdx
@@ -3,6 +3,6 @@ title: "Python"
 url: "https://github.com/Portkey-AI/portkey-python-sdk/tags"
 ---
 
-<Card title="Schedule Call" href="https://portkey.sh/demo-21" icon="calendar" horizontal>
+<Card title="Schedule Call" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action" icon="calendar" horizontal>
 Discuss how Portkey can enhance your organization's AI infrastructure
 </Card>

--- a/docs.json
+++ b/docs.json
@@ -2452,7 +2452,7 @@
       },
       {
         "label": "Book Demo",
-        "href": "https://portkey.sh/demo-18"
+        "href": "https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action"
       }
     ],
     "primary": {
@@ -4071,7 +4071,7 @@
     },
     {
       "source": "/demo?ref=portkey.ai",
-      "destination": "https://portkey.ai/book-a-demo"
+      "destination": "https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action"
     }
   ],
   "seo": {

--- a/guides/use-cases/openai-computer-use.mdx
+++ b/guides/use-cases/openai-computer-use.mdx
@@ -444,7 +444,7 @@ Learn about fallbacks, load balancing, and retry mechanisms.
 </CardGroup>
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>
 
 **Join our Community**

--- a/guides/use-cases/track-costs-using-metadata.mdx
+++ b/guides/use-cases/track-costs-using-metadata.mdx
@@ -287,4 +287,4 @@ Once you’ve integrated metadata tagging and the Analytics API, you can:
 2. **[Implement Fallback Strategies for Cost Control](/product/ai-gateway/fallbacks)**
 3. **[Explore Portkey’s Prompt Management](/product/prompt-library)**
 
-Need enterprise-grade cost tracking? **[Contact Sales](https://calendly.com/portkey-ai)** for custom analytics solutions.
+Need enterprise-grade cost tracking? **[Contact Sales](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action

--- a/integrations/agents/agentcore.mdx
+++ b/integrations/agents/agentcore.mdx
@@ -234,4 +234,4 @@ For best performance, deploy your Portkey gateway in the same AWS Region as your
 3. Expand beyond a single model by adding fallbacks or conditional routing rules in Portkey Configs
 4. Coordinate with AWS AgentCore Gateway to expose Portkey-observed tools for deeper analytics across both platforms
 
-Need help? [Book a session with Portkey](https://calendly.com/portkey-ai) to review deployment best practices across Portkey and AgentCore.
+Need help? [Book a session with Portkey](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action

--- a/integrations/agents/crewai.mdx
+++ b/integrations/agents/crewai.mdx
@@ -795,7 +795,7 @@ Here's a basic configuration to route requests to OpenAI, specifically using GPT
   <Card title="CrewAI Docs" icon="book" href="https://docs.crewai.com/">
     <p>Official CrewAI documentation</p>
   </Card>
-  <Card title="Book a Demo" icon="calendar" href="https://calendly.com/portkey-ai">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/integrations/agents/langgraph.mdx
+++ b/integrations/agents/langgraph.mdx
@@ -998,7 +998,7 @@ Here's a basic configuration to route requests to OpenAI, specifically using GPT
     <p>Official Portkey documentation</p>
   </Card>
 
-  <Card title="Book a Demo" icon="calendar" href="https://calendly.com/portkey-ai">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/integrations/agents/livekit.mdx
+++ b/integrations/agents/livekit.mdx
@@ -457,5 +457,5 @@ Implement real-time protection for your LLM interactions with automatic detectio
 - [Learn about guardrails](/product/guardrails)
 
 <Note>
-For enterprise support and custom features for your LiveKit deployment, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features for your LiveKit deployment, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/integrations/agents/mastra-agents.mdx
+++ b/integrations/agents/mastra-agents.mdx
@@ -801,7 +801,7 @@ For detailed key management instructions, see our [API Keys documentation](/api-
     <p>Example implementations for various use cases</p>
   </Card>
 
-  <Card title="Book a Demo" icon="calendar" href="https://portkey.sh/demo">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/integrations/agents/openai-agents-ts.mdx
+++ b/integrations/agents/openai-agents-ts.mdx
@@ -894,7 +894,7 @@ Monitor usage in Portkey dashboard:
     <p>Example implementations for various use cases</p>
   </Card>
 
-  <Card title="Book a Demo" href="https://portkey.sh/openai-agents">
+  <Card title="Book a Demo" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/integrations/agents/openai-agents.mdx
+++ b/integrations/agents/openai-agents.mdx
@@ -1193,7 +1193,7 @@ Monitor usage in Portkey dashboard:
     <p>Example implementations for various use cases</p>
   </Card>
 
-  <Card title="Book a Demo" href="https://portkey.sh/openai-agents">
+  <Card title="Book a Demo" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/integrations/agents/pydantic-ai.mdx
+++ b/integrations/agents/pydantic-ai.mdx
@@ -1089,7 +1089,7 @@ Here's a basic configuration to route requests to OpenAI, specifically using GPT
     <p>Official Portkey documentation</p>
   </Card>
 
-  <Card title="Book a Demo" icon="calendar" href="https://calendly.com/portkey-ai">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/integrations/agents/strands-backup.mdx
+++ b/integrations/agents/strands-backup.mdx
@@ -509,7 +509,7 @@ for attempt in range(3):
     <p>Official Portkey documentation</p>
   </Card>
 
-  <Card title="Book a Demo" icon="calendar" href="https://calendly.com/portkey-ai">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/integrations/agents/strands.mdx
+++ b/integrations/agents/strands.mdx
@@ -548,7 +548,7 @@ All of this works automatically with your existing Strands agents—no code chan
   <Card title="Strands Agents Docs" icon="book" href="https://strandsagents.com/">
   </Card>
 
-  <Card title="Book a Demo" icon="calendar" href="https://calendly.com/portkey-ai">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/integrations/libraries/anthropic-computer-use.mdx
+++ b/integrations/libraries/anthropic-computer-use.mdx
@@ -302,5 +302,5 @@ Portkey provides multiple security layers:
 
 
 <Note>
-For enterprise support and custom features for your development teams, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features for your development teams, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/integrations/libraries/openai-agent-builder-python.mdx
+++ b/integrations/libraries/openai-agent-builder-python.mdx
@@ -290,7 +290,7 @@ client = AsyncOpenAI(
   <Card title="OpenAI Agents Docs" icon="book" href="https://openai.github.io/openai-agents-python/">
     Official documentation
   </Card>
-  <Card title="Book a Demo" icon="calendar" href="https://portkey.sh/openai-agents">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     Get implementation guidance
   </Card>
 </CardGroup>

--- a/integrations/libraries/openai-agent-builder.mdx
+++ b/integrations/libraries/openai-agent-builder.mdx
@@ -290,7 +290,7 @@ const client = new OpenAI({
   <Card title="OpenAI Agents Docs" icon="book" href="https://openai.github.io/openai-agents-js/">
     Official documentation
   </Card>
-  <Card title="Book a Demo" icon="calendar" href="https://portkey.sh/openai-agents">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     Get implementation guidance
   </Card>
 </CardGroup>

--- a/integrations/libraries/openwebui.mdx
+++ b/integrations/libraries/openwebui.mdx
@@ -480,5 +480,5 @@ For other providers (Gemini, Vertex AI), add parameters via `override_params` in
 - [GitHub Repository](https://github.com/Portkey-AI)
 
 <Note>
-For enterprise support, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/integrations/llms/bedrock/bedrock-knowledgebase.mdx
+++ b/integrations/llms/bedrock/bedrock-knowledgebase.mdx
@@ -404,5 +404,5 @@ Now that you can create and build a full RAG application with your knowledge bas
 - Configure [Fallbacks](/product/ai-gateway/fallbacks) for high availability.
 
 <Note>
-For enterprise support with your AWS Bedrock integration, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support with your AWS Bedrock integration, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/integrations/tracing-providers/honeyhive.mdx
+++ b/integrations/tracing-providers/honeyhive.mdx
@@ -289,5 +289,5 @@ def call_openai():
 - [Portkey Python SDK Reference](/api-reference/sdk)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/integrations/tracing-providers/langfuse.mdx
+++ b/integrations/tracing-providers/langfuse.mdx
@@ -274,5 +274,5 @@ client = OpenAI(
 - [Portkey Python SDK Reference](/api-reference/sdk)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/integrations/tracing-providers/langsmith.mdx
+++ b/integrations/tracing-providers/langsmith.mdx
@@ -270,5 +270,5 @@ If you're already using LangSmith with OpenAI, migrating to use Portkey is simpl
 * [Portkey Python SDK Reference](/api-reference/sdk)
 
 <Note>
-  For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+  For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/product/administration/enforce-budget-and-rate-limit.mdx
+++ b/product/administration/enforce-budget-and-rate-limit.mdx
@@ -125,4 +125,4 @@ You can add additional recipients such as finance team members, department heads
 
 These features are available to Portkey Enterprise customers and select Pro users. To enable these features for your account, please contact [support@portkey.ai](mailto:support@portkey.ai) or join the [Portkey Discord](https://portkey.ai/community) community.
 
-To learn more about the Portkey Enterprise plan, [schedule a consultation](https://portkey.sh/demo-16).
+To learn more about the Portkey Enterprise plan, [schedule a consultation](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action).

--- a/product/ai-gateway/virtual-keys/budget-limits.mdx
+++ b/product/ai-gateway/virtual-keys/budget-limits.mdx
@@ -87,4 +87,4 @@ Budget Limits is currently available **exclusively to Portkey Enterprise** custo
 
 ## Enterprise Plan
 
-To discuss Portkey Enterprise plan details and pricing, [you can schedule a quick call here](https://portkey.sh/demo-16).
+To discuss Portkey Enterprise plan details and pricing, [you can schedule a quick call here](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action).

--- a/product/ai-gateway/virtual-keys/rate-limits.mdx
+++ b/product/ai-gateway/virtual-keys/rate-limits.mdx
@@ -74,4 +74,4 @@ Rate Limits is currently available **exclusively to Portkey Enterprise** custome
 
 ## Enterprise Plan
 
-To discuss Portkey Enterprise plan details and pricing, [you can schedule a quick call here](https://portkey.sh/demo-16).
+To discuss Portkey Enterprise plan details and pricing, [you can schedule a quick call here](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action).

--- a/product/enterprise-offering.mdx
+++ b/product/enterprise-offering.mdx
@@ -66,7 +66,7 @@ mode: "wide"
 ## Interested? Schedule a Call Below
 
 <iframe
-  src="https://portkey.sh/demo-17"
+  src="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action"
   width="100%"
   height="600"
   frameBorder="0"

--- a/product/enterprise-offering/audit-logs.mdx
+++ b/product/enterprise-offering/audit-logs.mdx
@@ -134,7 +134,7 @@ Portkey's Audit Logs include enterprise-grade capabilities:
 
 For questions about Audit Logs or assistance with interpreting specific entries, contact [Portkey support](mailto:support@portkey.ai) or reach out on [Discord](https://portkey.sh/reddit-discord).
 
-<Card title="Schedule a Demo" icon="calendar" color="#0e7490" href="https://portkey.sh/demo-20">
+<Card title="Schedule a Demo" icon="calendar" color="#0e7490" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
   Ready to bring enterprise-grade governance to your AI infrastructure? Learn more about Portkey's Audit Logs and other enterprise features in a personalized demo.
 
 </Card>

--- a/product/product-feature-comparison.mdx
+++ b/product/product-feature-comparison.mdx
@@ -26,7 +26,7 @@ Portkey has a generous free tier (10k requests/month) on our **Dev** plan — bu
 Enterprise customers leverage Portkey to **observe**, **govern**, and **optimize** their Gen AI services at scale across the entire org. Our Enterprise plan offers advanced security configurations, dedicated support, and customized infrastructure designed for high-volume production deployments.
 
 <CardGroup cols={2}>
-<Card title="For Scale & Performance" icon="gauge-high" iconType="solid" color="#0e7490" href="https://portkey.sh/demo-20">
+<Card title="For Scale & Performance" icon="gauge-high" iconType="solid" color="#0e7490" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
   ▪️ Processing millions of requests
 
   ▪️ Need Five 9s reliability
@@ -35,7 +35,7 @@ Enterprise customers leverage Portkey to **observe**, **govern**, and **optimize
 
   ▪️ Building for multiple partner teams and departments
 </Card>
-  <Card title="For Security & Compliance" icon="shield-check" iconType="solid" color="#0e7490" href="https://portkey.sh/demo-20">
+  <Card title="For Security & Compliance" icon="shield-check" iconType="solid" color="#0e7490" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     ▪️ SOC2, ISO27001, GDPR, HIPAA
 
     ▪️ VPC/Airgapped deployment
@@ -98,7 +98,7 @@ Here's a detailed comparison of our plans to help you choose the right solution 
     icon="building"
     iconType="solid"
     color="#0e7490"
-    href="https://portkey.sh/demo-20"
+    href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action"
   >
     Enterprise-grade security, compliance, and scalability with flexible deployment.
     
@@ -113,7 +113,7 @@ Here's a detailed comparison of our plans to help you choose the right solution 
 
 | <h3>Product / Plan</h3>                                        | <Card horizontal="true" title="Open Source" icon="github"></Card>                                         | <Card horizontal="true" title="Dev (Free Forever)" icon="dev"></Card>                      | <Card horizontal="true" title="Pro ($49/Month)" icon="rectangle-pro" iconType="solid"></Card>                           | <Card horizontal="true" title="Enterprise (Custom)" icon="building" iconType="solid"></Card>                        |
 |:--------------------------------------------------- | :---------------------------------------------------- | :---------------------------------------- | :----------------------------------------- | :------------------------------------------ |
-| Get Started                                         | <Card horizontal="true" title="Run Local" href="https://github.com/portkey-ai/gateway"></Card> | <Card title="Sign Up" href="https://app.portkey.ai/signup" horizontal="true"></Card> | <Card title="Upgrade" href="https://app.portkey.ai/signup" horizontal="true"></Card>  | <Card title="Book Call" href="https://portkey.sh/demo-20" horizontal="true"></Card> |
+| Get Started                                         | <Card horizontal="true" title="Run Local" href="https://github.com/portkey-ai/gateway"></Card> | <Card title="Sign Up" href="https://app.portkey.ai/signup" horizontal="true"></Card> | <Card title="Upgrade" href="https://app.portkey.ai/signup" horizontal="true"></Card>  | <Card title="Book Call" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action" horizontal="true"></Card> |
 | Requests per Month                                  | No Limit                                             | 10K                                      | 100K                                      | Custom                                  |
 | Overage                                             | -                                                    | No Overage Allowed                                   | $9/Month<br />for Every 100K<br />Up to 3M Requests | Custom Pricing                                         |
 | <h4>Observability</h4>                                 |                                                      |                                          |                                           |                                            |
@@ -268,7 +268,7 @@ All enterprise deployment options include comprehensive security features such a
 <Card title="Ready to explore Enterprise options?" icon="calendar" color="#0e7490">
   **Schedule a 30-minute consultation** with our solutions team to discuss your specific requirements and see a live demo.
   
-  [Book Your Consultation](https://calendly.com/portkey-ai/quick-meeting)
+  [Book Your Consultation](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Card>
 
 ## Enterprise Implementation Journey
@@ -288,7 +288,7 @@ All enterprise deployment options include comprehensive security features such a
   </Step>
 </Steps>
 
-<Card title="Not sure which deployment model is right for you?" icon="lightbulb" href="https://portkey.sh/demo-20">
+<Card title="Not sure which deployment model is right for you?" icon="lightbulb" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
   Our enterprise team can help assess your requirements and recommend the optimal deployment strategy for your organization's specific needs.
 
   Book a Consultation here.
@@ -297,7 +297,7 @@ All enterprise deployment options include comprehensive security features such a
 ## Interested? Schedule a Call Below
 
 <iframe
-  src="https://calendly.com/portkey-ai/quick-meeting"
+  src="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action"
   width="100%"
   height="600"
   frameBorder="0"

--- a/snippets/portkey-advanced-features.mdx
+++ b/snippets/portkey-advanced-features.mdx
@@ -278,5 +278,5 @@ When a team reaches their budget limit:
 - [GitHub Repository](https://github.com/Portkey-AI)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/agents/crewai.mdx
+++ b/virtual_key_old/integrations/agents/crewai.mdx
@@ -816,7 +816,7 @@ Here's a basic configuration to route requests to OpenAI, specifically using GPT
   <Card title="CrewAI Docs" icon="book" href="https://docs.crewai.com/">
     <p>Official CrewAI documentation</p>
   </Card>
-  <Card title="Book a Demo" icon="calendar" href="https://calendly.com/portkey-ai">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/virtual_key_old/integrations/agents/langgraph.mdx
+++ b/virtual_key_old/integrations/agents/langgraph.mdx
@@ -1016,7 +1016,7 @@ Here's a basic configuration to route requests to OpenAI, specifically using GPT
     <p>Official Portkey documentation</p>
   </Card>
 
-  <Card title="Book a Demo" icon="calendar" href="https://calendly.com/portkey-ai">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/virtual_key_old/integrations/agents/livekit.mdx
+++ b/virtual_key_old/integrations/agents/livekit.mdx
@@ -480,5 +480,5 @@ Implement real-time protection for your LLM interactions with automatic detectio
 - [Learn about guardrails](/product/guardrails)
 
 <Note>
-For enterprise support and custom features for your LiveKit deployment, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features for your LiveKit deployment, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/agents/openai-agents-ts.mdx
+++ b/virtual_key_old/integrations/agents/openai-agents-ts.mdx
@@ -917,7 +917,7 @@ Monitor usage in Portkey dashboard:
     <p>Example implementations for various use cases</p>
   </Card>
 
-  <Card title="Book a Demo" href="https://portkey.sh/openai-agents">
+  <Card title="Book a Demo" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/virtual_key_old/integrations/agents/openai-agents.mdx
+++ b/virtual_key_old/integrations/agents/openai-agents.mdx
@@ -1216,7 +1216,7 @@ Monitor usage in Portkey dashboard:
     <p>Example implementations for various use cases</p>
   </Card>
 
-  <Card title="Book a Demo" href="https://portkey.sh/openai-agents">
+  <Card title="Book a Demo" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/virtual_key_old/integrations/agents/pydantic-ai.mdx
+++ b/virtual_key_old/integrations/agents/pydantic-ai.mdx
@@ -1184,7 +1184,7 @@ Here's a basic configuration to route requests to OpenAI, specifically using GPT
     <p>Official Portkey documentation</p>
   </Card>
 
-  <Card title="Book a Demo" icon="calendar" href="https://calendly.com/portkey-ai">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/virtual_key_old/integrations/agents/strands-backup.mdx
+++ b/virtual_key_old/integrations/agents/strands-backup.mdx
@@ -514,7 +514,7 @@ for attempt in range(3):
     <p>Official Portkey documentation</p>
   </Card>
 
-  <Card title="Book a Demo" icon="calendar" href="https://calendly.com/portkey-ai">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/virtual_key_old/integrations/agents/strands.mdx
+++ b/virtual_key_old/integrations/agents/strands.mdx
@@ -549,7 +549,7 @@ All of this works automatically with your existing Strands agents—no code chan
   <Card title="Strands Agents Docs" icon="book" href="https://strandsagents.com/">
   </Card>
 
-  <Card title="Book a Demo" icon="calendar" href="https://calendly.com/portkey-ai">
+  <Card title="Book a Demo" icon="calendar" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     <p>Get personalized guidance on implementing this integration</p>
   </Card>
 </CardGroup>

--- a/virtual_key_old/integrations/libraries/anthropic-computer-use.mdx
+++ b/virtual_key_old/integrations/libraries/anthropic-computer-use.mdx
@@ -292,5 +292,5 @@ Portkey provides multiple security layers:
 
 
 <Note>
-For enterprise support and custom features for your development teams, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features for your development teams, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/libraries/anythingllm.mdx
+++ b/virtual_key_old/integrations/libraries/anythingllm.mdx
@@ -371,5 +371,5 @@ When a team reaches their budget limit:
 - [GitHub Repository](https://github.com/Portkey-AI)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/libraries/cline.mdx
+++ b/virtual_key_old/integrations/libraries/cline.mdx
@@ -413,5 +413,5 @@ Schedule a 1:1 call with our team to see how Portkey can transform your developm
 </Card>
 
 <Note>
-For enterprise support and custom features for your development teams, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features for your development teams, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/libraries/codex.mdx
+++ b/virtual_key_old/integrations/libraries/codex.mdx
@@ -392,5 +392,5 @@ Yes! Portkey fully integrates with [OpenAI's open source Codex CLI](https://gith
 - [GitHub Repository](https://github.com/Portkey-AI)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/libraries/goose.mdx
+++ b/virtual_key_old/integrations/libraries/goose.mdx
@@ -391,5 +391,5 @@ When a team reaches their budget limit:
 - [GitHub Repository](https://github.com/Portkey-AI)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/libraries/janhq.mdx
+++ b/virtual_key_old/integrations/libraries/janhq.mdx
@@ -369,5 +369,5 @@ When a team reaches their budget limit:
 - [GitHub Repository](https://github.com/Portkey-AI)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/libraries/librechat.mdx
+++ b/virtual_key_old/integrations/libraries/librechat.mdx
@@ -435,5 +435,5 @@ When a team reaches their budget limit:
 - [GitHub Repository](https://github.com/Portkey-AI)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/libraries/n8n.mdx
+++ b/virtual_key_old/integrations/libraries/n8n.mdx
@@ -394,5 +394,5 @@ You can control model access by:
 - [GitHub Repository](https://github.com/Portkey-AI)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/libraries/openwebui.mdx
+++ b/virtual_key_old/integrations/libraries/openwebui.mdx
@@ -667,5 +667,5 @@ When a team reaches their budget limit:
 - [GitHub Repository](https://github.com/Portkey-AI)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/libraries/roo-code.mdx
+++ b/virtual_key_old/integrations/libraries/roo-code.mdx
@@ -412,5 +412,5 @@ Schedule a 1:1 call with our team to see how Portkey can transform your developm
 </Card>
 
 <Note>
-For enterprise support and custom features for your development teams, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features for your development teams, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/libraries/zed.mdx
+++ b/virtual_key_old/integrations/libraries/zed.mdx
@@ -381,5 +381,5 @@ When a team reaches their budget limit:
 - [GitHub Repository](https://github.com/Portkey-AI)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/integrations/tracing-providers/langfuse.mdx
+++ b/virtual_key_old/integrations/tracing-providers/langfuse.mdx
@@ -298,5 +298,5 @@ client = OpenAI(
 - [Portkey Python SDK Reference](/api-reference/portkey-sdk-client)
 
 <Note>
-For enterprise support and custom features, contact our [enterprise team](https://calendly.com/portkey-ai).
+For enterprise support and custom features, contact our [enterprise team](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Note>

--- a/virtual_key_old/product/administration/enforce-budget-and-rate-limit.mdx
+++ b/virtual_key_old/product/administration/enforce-budget-and-rate-limit.mdx
@@ -121,4 +121,4 @@ You can add additional recipients such as finance team members, department heads
 
 These features are available to Portkey Enterprise customers and select Pro users. To enable these features for your account, please contact [support@portkey.ai](mailto:support@portkey.ai) or join the [Portkey Discord](https://portkey.ai/community) community.
 
-To learn more about the Portkey Enterprise plan, [schedule a consultation](https://portkey.sh/demo-16).
+To learn more about the Portkey Enterprise plan, [schedule a consultation](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action).

--- a/virtual_key_old/product/ai-gateway/virtual-keys/budget-limits.mdx
+++ b/virtual_key_old/product/ai-gateway/virtual-keys/budget-limits.mdx
@@ -85,4 +85,4 @@ Budget Limits is currently available **exclusively to Portkey Enterprise** custo
 
 ## Enterprise Plan
 
-To discuss Portkey Enterprise plan details and pricing, [you can schedule a quick call here](https://portkey.sh/demo-16).
+To discuss Portkey Enterprise plan details and pricing, [you can schedule a quick call here](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action).

--- a/virtual_key_old/product/ai-gateway/virtual-keys/rate-limits.mdx
+++ b/virtual_key_old/product/ai-gateway/virtual-keys/rate-limits.mdx
@@ -74,4 +74,4 @@ Rate Limits is currently available **exclusively to Portkey Enterprise** custome
 
 ## Enterprise Plan
 
-To discuss Portkey Enterprise plan details and pricing, [you can schedule a quick call here](https://portkey.sh/demo-16).
+To discuss Portkey Enterprise plan details and pricing, [you can schedule a quick call here](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action).

--- a/virtual_key_old/product/enterprise-offering.mdx
+++ b/virtual_key_old/product/enterprise-offering.mdx
@@ -69,7 +69,7 @@ mode: "wide"
 ## Interested? Schedule a Call Below
 
 <iframe
-  src="https://portkey.sh/demo-17"
+  src="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action"
   width="100%"
   height="600"
   frameBorder="0"

--- a/virtual_key_old/product/enterprise-offering/audit-logs.mdx
+++ b/virtual_key_old/product/enterprise-offering/audit-logs.mdx
@@ -133,7 +133,7 @@ Portkey's Audit Logs include enterprise-grade capabilities:
 
 For questions about Audit Logs or assistance with interpreting specific entries, contact [Portkey support](mailto:support@portkey.ai) or reach out on [Discord](https://portkey.sh/reddit-discord).
 
-<Card title="Schedule a Demo" icon="calendar" color="#0e7490" href="https://portkey.sh/demo-20">
+<Card title="Schedule a Demo" icon="calendar" color="#0e7490" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
   Ready to bring enterprise-grade governance to your AI infrastructure? Learn more about Portkey's Audit Logs and other enterprise features in a personalized demo.
 
 </Card>

--- a/virtual_key_old/product/product-feature-comparison.mdx
+++ b/virtual_key_old/product/product-feature-comparison.mdx
@@ -26,7 +26,7 @@ Portkey has a generous free tier (10k requests/month) on our **Dev** plan — bu
 Enterprise customers leverage Portkey to **observe**, **govern**, and **optimize** their Gen AI services at scale across the entire org. Our Enterprise plan offers advanced security configurations, dedicated support, and customized infrastructure designed for high-volume production deployments.
 
 <CardGroup cols={2}>
-<Card title="For Scale & Performance" icon="gauge-high" iconType="solid" color="#0e7490" href="https://portkey.sh/demo-20">
+<Card title="For Scale & Performance" icon="gauge-high" iconType="solid" color="#0e7490" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
   ▪️ Processing millions of requests
 
   ▪️ Need Five 9s reliability
@@ -35,7 +35,7 @@ Enterprise customers leverage Portkey to **observe**, **govern**, and **optimize
 
   ▪️ Building for multiple partner teams and departments
 </Card>
-  <Card title="For Security & Compliance" icon="shield-check" iconType="solid" color="#0e7490" href="https://portkey.sh/demo-20">
+  <Card title="For Security & Compliance" icon="shield-check" iconType="solid" color="#0e7490" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     ▪️ SOC2, ISO27001, GDPR, HIPAA
 
     ▪️ VPC/Airgapped deployment
@@ -98,7 +98,7 @@ Here's a detailed comparison of our plans to help you choose the right solution 
     icon="building"
     iconType="solid"
     color="#0e7490"
-    href="https://portkey.sh/demo-20"
+    href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action"
   >
     Enterprise-grade security, compliance, and scalability with flexible deployment.
     
@@ -113,7 +113,7 @@ Here's a detailed comparison of our plans to help you choose the right solution 
 
 | <h3>Product / Plan</h3>                                        | <Card horizontal="true" title="Open Source" icon="github"></Card>                                         | <Card horizontal="true" title="Dev (Free Forever)" icon="dev"></Card>                      | <Card horizontal="true" title="Pro ($49/Month)" icon="rectangle-pro" iconType="solid"></Card>                           | <Card horizontal="true" title="Enterprise (Custom)" icon="building" iconType="solid"></Card>                        |
 |:--------------------------------------------------- | :---------------------------------------------------- | :---------------------------------------- | :----------------------------------------- | :------------------------------------------ |
-| Get Started                                         | <Card horizontal="true" title="Run Local" href="https://github.com/portkey-ai/gateway"></Card> | <Card title="Sign Up" href="https://app.portkey.ai/signup" horizontal="true"></Card> | <Card title="Upgrade" href="https://app.portkey.ai/signup" horizontal="true"></Card>  | <Card title="Book Call" href="https://portkey.sh/demo-20" horizontal="true"></Card> |
+| Get Started                                         | <Card horizontal="true" title="Run Local" href="https://github.com/portkey-ai/gateway"></Card> | <Card title="Sign Up" href="https://app.portkey.ai/signup" horizontal="true"></Card> | <Card title="Upgrade" href="https://app.portkey.ai/signup" horizontal="true"></Card>  | <Card title="Book Call" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action" horizontal="true"></Card> |
 | Requests per Month                                  | No Limit                                             | 10K                                      | 100K                                      | Custom                                  |
 | Overage                                             | -                                                    | No Overage Allowed                                   | $9/Month<br />for Every 100K<br />Up to 3M Requests | Custom Pricing                                         |
 | <h4>Observability</h4>                                 |                                                      |                                          |                                           |                                            |
@@ -268,7 +268,7 @@ All enterprise deployment options include comprehensive security features such a
 <Card title="Ready to explore Enterprise options?" icon="calendar" color="#0e7490">
   **Schedule a 30-minute consultation** with our solutions team to discuss your specific requirements and see a live demo.
   
-  [Book Your Consultation](https://calendly.com/portkey-ai/quick-meeting)
+  [Book Your Consultation](https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action
 </Card>
 
 ## Enterprise Implementation Journey
@@ -288,7 +288,7 @@ All enterprise deployment options include comprehensive security features such a
   </Step>
 </Steps>
 
-<Card title="Not sure which deployment model is right for you?" icon="lightbulb" href="https://portkey.sh/demo-20">
+<Card title="Not sure which deployment model is right for you?" icon="lightbulb" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
   Our enterprise team can help assess your requirements and recommend the optimal deployment strategy for your organization's specific needs.
 
   Book a Consultation here.
@@ -297,7 +297,7 @@ All enterprise deployment options include comprehensive security features such a
 ## Interested? Schedule a Call Below
 
 <iframe
-  src="https://calendly.com/portkey-ai/quick-meeting"
+  src="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action"
   width="100%"
   height="600"
   frameBorder="0"


### PR DESCRIPTION
…eway URL

Replace all portkey.sh/demo-*, portkey.sh/openai-agents, portkey.ai/book-a-demo, and calendly.com/portkey-ai links across 67 files with the unified Palo Alto Networks AI Gateway demo URL. Also remove email support links where they appeared alongside the demo link, leaving only the demo link.