### PR TITLE
docs: add Gateway URLs organisation setting page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -249,6 +249,7 @@
                           "product/enterprise-offering/org-management/user-roles-and-permissions",
                           "product/enterprise-offering/org-management/api-keys-authn-and-authz",
                           "product/enterprise-offering/org-management/api-key-rotation",
+                          "product/enterprise-offering/org-management/gateway-urls",
                           "product/enterprise-offering/org-management/jwt",
                           {
                             "group": "SCIM",

--- a/product/enterprise-offering/org-management/gateway-urls.mdx
+++ b/product/enterprise-offering/org-management/gateway-urls.mdx
@@ -1,0 +1,75 @@
+---
+title: "Gateway URLs"
+description: "Configure custom gateway endpoints for your organisation's AI gateway and MCP gateway deployments."
+---
+
+<Info>
+  Gateway URLs are available on the **Enterprise** plan only.
+</Info>
+
+The Gateway URLs settings let you point the Portkey dashboard at your own self-hosted gateway deployments instead of Portkey's cloud endpoints. Once configured, the dashboard uses your custom URLs when generating code snippets, running playground completions, and constructing MCP server endpoints.
+
+Both fields are set at the **organisation level** and apply across all workspaces within that organisation.
+
+---
+
+## Gateway URL
+
+The Gateway URL is the base URL of your self-hosted AI gateway. Setting it changes two things in the dashboard:
+
+- **Code snippets** — the `baseURL` shown in the Model Catalog and Getting Started pages will use your gateway URL instead of `https://api.portkey.ai/v1`.
+- **Playground completions** — prompt completions triggered from the dashboard are proxied through this URL.
+
+If this field is left blank, the dashboard falls back to Portkey's cloud gateway at `https://api.portkey.ai/v1`.
+
+<Note>
+  The trailing `/v1` is automatically normalised. Whether you enter `https://gateway.yourcompany.com` or `https://gateway.yourcompany.com/v1`, the dashboard will always use the `/v1`-suffixed form.
+</Note>
+
+---
+
+## MCP Gateway URL
+
+The MCP Gateway URL is the base URL of your self-hosted MCP gateway. It is used to construct the endpoint URL for each MCP server registered in your organisation.
+
+For an MCP server with slug `my-server`, the resulting endpoint URL will be:
+
+```
+<mcp-gateway-url>/my-server/mcp
+```
+
+If this field is left blank, the dashboard falls back to Portkey's default MCP gateway at `https://mcp.portkey.ai`.
+
+---
+
+## How to Configure
+
+1. Navigate to **Settings** in the Portkey dashboard.
+2. Under the **Organisation** section, click **General**.
+3. Scroll to the **Gateway URLs** section.
+4. Enter your gateway's base URL in the **Gateway URL** field (e.g. `https://gateway.yourcompany.com`).
+5. Enter your MCP gateway's base URL in the **MCP Gateway URL** field if applicable (e.g. `https://mcp.yourcompany.com`).
+6. Click outside the input field. The value saves automatically — there is no separate save button.
+
+To clear either value and revert to the Portkey default, delete the URL from the field and click outside it.
+
+<Warning>
+  Only organisation members with the **Admin** or **Owner** role can update these settings.
+</Warning>
+
+---
+
+## Private and Self-Hosted Deployments
+
+<Note>
+  If you are running a **private or self-hosted deployment** of Portkey, the Gateway URL shown in the dashboard is controlled at the infrastructure level by your deployment team via the `INTERNAL_GATEWAY_URL` or `GATEWAY_BASE_URL` environment variable. In this case, the value entered in the UI has no effect — contact your deployment administrator to change the gateway endpoint.
+</Note>
+
+---
+
+## Related Topics
+
+<Card title="Organizations" href="/product/enterprise-offering/org-management/organizations"/>
+<Card title="Workspaces" href="/product/enterprise-offering/org-management/workspaces"/>
+<Card title="MCP Gateway" href="/product/mcp-gateway"/>
+<Card title="Self-Hosting" href="/self-hosting"/>


### PR DESCRIPTION
Documents the Enterprise-only Gateway URL and MCP Gateway URL fields in Organisation General Settings — what they control, how to configure them, fallback behavior, and the private deployment override note.

Also registers the new page in docs.json under the org-management nav group.