### PR TITLE
feat(docs): add Nexus Shield guardrail integration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -524,6 +524,7 @@
                   "integrations/guardrails/lasso",
                   "integrations/guardrails/lakera",
                   "integrations/guardrails/mistral",
+                  "integrations/guardrails/nexus-shield",
                   "integrations/guardrails/pangea",
                   "integrations/guardrails/patronus-ai",
                   "integrations/guardrails/palo-alto-panw-prisma",

--- a/docs/integrations/nexus_shield.md
+++ b/docs/integrations/nexus_shield.md
@@ -1,0 +1,39 @@
+# Nexus Shield Integration (Sub-10ms Guardrail Proxy)
+
+Nexus Shield provides in-RAM PII sanitization and security guardrails for Portkey-routed LLM requests with sub-10ms overhead.
+
+## Usage with Portkey
+
+You can route your requests through Nexus Shield by specifying its endpoint in your Portkey configuration or setting `base_url`.
+
+```python
+from portkey_ai import Portkey
+
+portkey = Portkey(
+    api_key="PORTKEY_API_KEY",
+    base_url="https://api.nexusshield.ai/v1",
+    custom_headers={"X-API-Key": "nx_live_YOUR_KEY"},
+)
+
+response = portkey.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "Hello, my phone is 555-0199"}],
+)
+
+print(response)
+```
+
+## Features
+
+- **Sub-10ms Overhead:** Real-time RAM pattern evaluation before upstream LLM calls.
+- **Zero-Log PII Redaction:** Sanitizes sensitive information without disk persistence.
+
+## Get a Trial API Key
+
+Register for a 14-day free trial at [api.nexusshield.ai](https://api.nexusshield.ai):
+
+```bash
+curl -X POST https://api.nexusshield.ai/v1/auth/register-trial \
+  -H "Content-Type: application/json" \
+  -d '{"email":"you@company.com"}'
+```

--- a/integrations/guardrails/nexus-shield.mdx
+++ b/integrations/guardrails/nexus-shield.mdx
@@ -1,0 +1,44 @@
+---
+title: "Nexus Shield"
+description: "Sub-10ms in-RAM PII sanitization and security guardrail proxy for Portkey"
+---
+
+# Nexus Shield Integration (Sub-10ms Guardrail Proxy)
+
+Nexus Shield provides in-RAM PII sanitization and security guardrails for Portkey-routed LLM requests with sub-10ms overhead.
+
+## Usage with Portkey
+
+You can route your requests through Nexus Shield by specifying its endpoint in your Portkey configuration or setting `base_url`.
+
+```python
+from portkey_ai import Portkey
+
+portkey = Portkey(
+    api_key="PORTKEY_API_KEY",
+    base_url="https://api.nexusshield.ai/v1",
+    custom_headers={"X-API-Key": "nx_live_YOUR_KEY"},
+)
+
+response = portkey.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "Hello, my phone is 555-0199"}],
+)
+
+print(response)
+```
+
+## Features
+
+- **Sub-10ms Overhead:** Real-time RAM pattern evaluation before upstream LLM calls.
+- **Zero-Log PII Redaction:** Sanitizes sensitive information without disk persistence.
+
+## Get a Trial API Key
+
+Register for a 14-day free trial at [api.nexusshield.ai](https://api.nexusshield.ai):
+
+```bash
+curl -X POST https://api.nexusshield.ai/v1/auth/register-trial \
+  -H "Content-Type: application/json" \
+  -d '{"email":"you@company.com"}'
+```


### PR DESCRIPTION
## Summary
Adds integration documentation for **Nexus Shield** — a sub-10ms in-RAM PII sanitization and security guardrail proxy for Portkey routing.

## Changes Included
- Added integration guide with code examples showing how to pass `base_url` and custom headers for Nexus Shield with `Portkey`.

## Usage Preview
```python
from portkey_ai import Portkey

portkey = Portkey(
    api_key="PORTKEY_API_KEY",
    base_url="[https://api.nexusshield.ai/v1](https://api.nexusshield.ai/v1)",
    custom_headers={"x-nexus-api-key": "nx_live_YOUR_KEY"}
)

response = portkey.chat.completions.create(
    model="gpt-4o",
    messages=[{"role": "user", "content": "Hello, my phone is 555-0199"}]
)

print(response)
Checklist
[x] Verified Markdown formatting

[x] Followed repository contribution guidelines