### PR TITLE
docs: mark air-gapped deployment as legacy / no longer offered

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -318,7 +318,7 @@
                   
                   "self-hosting/fips-compliant-images",
                   {
-                    "group": "Air-Gapped Deployments",
+                    "group": "Air-Gapped Deployments (Legacy)",
                     "pages": [
                       "self-hosting/airgapped/model-pricing"
                     ]

--- a/enterprise/azure-deployment.mdx
+++ b/enterprise/azure-deployment.mdx
@@ -3,14 +3,18 @@ title: "Azure Deployment Architectures"
 description: "Complete architecture and service requirements for deploying Portkey on Azure"
 ---
 
-This guide provides complete architecture and service requirements for deploying Portkey on Azure for both **Hybrid** and **Full Private (Airgapped)** deployment models.
+import AirgappedLegacy from "/snippets/airgapped-legacy.mdx";
+
+This guide provides complete architecture and service requirements for deploying Portkey on Azure. **Hybrid** is the deployment model for all new Azure deployments; the **Full Private (Airgapped)** architecture is documented for reference and for customers with an existing air-gapped deployment.
+
+<AirgappedLegacy />
 
 ## Deployment Models
 
 | Deployment Model | Description |
 |:-----------------|:------------|
 | **Hybrid** | Data Plane runs in your Azure environment; Control Plane hosted by Portkey |
-| **Full Private (Airgapped)** | Both Data Plane and Control Plane run entirely in your Azure environment |
+| **Full Private (Airgapped)** *(legacy — not offered)* | Both Data Plane and Control Plane run entirely in your Azure environment |
 
 ---
 
@@ -71,7 +75,7 @@ flowchart TB
 
 ---
 
-## Full Private (Airgapped) Deployment
+## Full Private (Airgapped) Deployment (Legacy — Not Offered)
 
 In a Full Private deployment, **all components** run within your Azure environment. This includes the complete Control Plane with the web dashboard, backend services, and analytics infrastructure.
 
@@ -222,8 +226,8 @@ The Gateway authenticates to Azure Foundry using one of these methods:
   <Step title="Hybrid Deployment" icon="cloud">
     Follow the [Azure Hybrid Deployment Guide](/product/enterprise-offering/private-cloud-deployments/azure) for step-by-step instructions.
   </Step>
-  <Step title="Full Private Deployment" icon="lock">
-    Contact the Portkey team for full private deployment Helm charts and license keys.
+  <Step title="Full Private Deployment (Legacy)" icon="lock">
+    No longer offered for new deployments. Existing air-gapped customers can [contact us](https://www.paloaltonetworks.in/ai-security/ai-gateway#contact?utm_source=portkey&utm_medium=referral&utm_campaign=prisma_airs&utm_content=docs_footer) for Helm charts and license keys.
   </Step>
   <Step title="Access Helm Charts" icon="code">
     All Helm charts are available at the [Portkey Helm repository](https://github.com/Portkey-AI/helm).

--- a/enterprise/poc.mdx
+++ b/enterprise/poc.mdx
@@ -3,7 +3,11 @@ title: "PoC Options"
 description: "Choose the fastest path to validate Portkey in your environment"
 ---
 
-Portkey offers three deployment models for evaluating our technology. Each model comes with **No-Cost** and **Paid** proof-of-concept (PoC) tracks so you can pick the path that best fits your procurement, legal and security needs.
+import AirgappedLegacy from "/snippets/airgapped-legacy.mdx";
+
+Portkey offers two deployment models for evaluating our technology — **SaaS Enterprise** and **Hybrid**. Each comes with **No-Cost** and **Paid** proof-of-concept (PoC) tracks so you can pick the path that best fits your procurement, legal and security needs.
+
+<AirgappedLegacy />
 
 ## Overview
 
@@ -12,8 +16,7 @@ Portkey offers three deployment models for evaluating our technology. Each model
 | **SaaS Enterprise** | Portkey Cloud<br />(multi-tenant) | **$0** | *Optional* NDA / MSA | 14 days | Sign up & request trial | Quick functional test |
 | **Hybrid<br />No-Cost** | Customer cloud<br />On-prem | **$0** | Standard MSA +<br />Order Form for Annual Contract | 30 days<br />*(auto-convert*) | Sign MSA & deploy gateway | On-prem eval with no risk |
 | **Hybrid<br />Paid** | Customer cloud<br />On-prem | **$3,000** (credited) | Short-form MSA | 30 days | Sign short MSA & deploy | Need lighter legal lift |
-| **Airgapped<br />No-Cost** | Fully offline environment | **$0** | Standard MSA +<br />Order Form for Annual Contract | 45–60 days<br />*(auto-convert*) | Sign MSA & receive images | Strict data-isolation needs |
-| **Air-gapped<br />Paid** | Fully offline environment | **$5,000** (credited) | Short-form MSA | 45–60 days | Sign short MSA & receive images | Offline eval + faster legal |
+| **Air-gapped**<br />*(No-Cost & Paid)* | Fully offline environment | *No longer offered* | — | — | — | Existing air-gapped customers only |
 
 ## SaaS Enterprise PoC
 <Steps>
@@ -84,7 +87,10 @@ Portkey offers three deployment models for evaluating our technology. Each model
 
 ---
 
-## Airgapped PoC
+## Airgapped PoC (No Longer Offered)
+
+The tracks below are retained for reference only — new air-gapped PoCs are not accepted. Existing air-gapped deployments remain supported.
+
 <Steps>
 <Step title="Why Choose Air-gapped" icon="lightbulb">
 * **No outbound traffic**: Gateway, logs, and all data remain inside your isolated network.
@@ -134,12 +140,11 @@ Not sure how to measure success? Common metrics include:
 
 <Step title="Choosing the Right PoC" icon="circle-check">
 * **SaaS** — Perfect for teams that want to get started ASAP, and are comfortable with cloud-hosted data.
-* **Hybrid** — Best when data must stay in your VPC but an internet connection is acceptable.
-* **Air-gapped** — Required when *no* external connectivity is permitted.
+* **Hybrid** — Best when data must stay in your VPC. Prompts, responses, and logs never leave your network; only operational metrics reach Portkey's control plane.
 </Step>
 
 <Step title="Trust & Compliance" icon="shield">
-During the PoC—**and beyond**—your security team can access Portkey’s SOC 2 Type II report and other certifications directly via our **[trust portal](https://trust.portkey.ai)**. For a security-first comparison of SaaS vs Hybrid vs Air-gapped, see **[Security by Deployment Model](/enterprise/security)**.
+During the PoC—**and beyond**—your security team can access Portkey’s SOC 2 Type II report and other certifications directly via our **[trust portal](https://trust.portkey.ai)**. For a security-first comparison of SaaS vs Hybrid, see **[Security by Deployment Model](/enterprise/security)**.
 </Step>
 
 <Step title="Extensions, Cancellations & Conversions" icon="calendar">

--- a/enterprise/pricing.mdx
+++ b/enterprise/pricing.mdx
@@ -4,7 +4,11 @@ mode: "center"
 noindex: "true"
 ---
 
+import AirgappedLegacy from "/snippets/airgapped-legacy.mdx";
+
 Portkey's enterprise pricing is designed to scale with your organization's AI ambitions while providing predictable costs and negotiable terms. Our Enterprise plan offers advanced security configurations, dedicated support, and customized infrastructure designed for high-volume production deployments.
+
+<AirgappedLegacy />
 
 ### Why Enterprises Choose Portkey
 
@@ -21,7 +25,7 @@ Portkey's enterprise pricing is designed to scale with your organization's AI am
   <Card title="For Security & Compliance" icon="shield-check" iconType="solid" color="#0e7490">
     ▪️ SOC2, ISO27001, GDPR, HIPAA
 
-    ▪️ VPC/Airgapped deployment
+    ▪️ VPC / Hybrid deployment
 
     ▪️ PII anonymization
 
@@ -35,10 +39,10 @@ Your Portkey pricing is a combination of four core elements:
 
 <CardGroup cols={2}>
   <Card title="1. Deployment Pattern" icon="diagram-project" href="#1-deployment-pattern">
-    Choose SaaS, Hybrid, or Airgapped based on your data and infrastructure requirements.
+    Choose SaaS or Hybrid based on your data and infrastructure requirements.
   </Card>
   <Card title="2. Gateway Deployments" icon="server" href="#2-production-gateway-deployments">
-    Specify the number of production gateway deployments for Hybrid or Airgapped.
+    Specify the number of production gateway deployments for Hybrid.
   </Card>
   <Card title="3. Gateway Request Volume" icon="chart-line" href="#3-gateway-request-volume">
     Number of requests sent through the Gateway, for SaaS or Hybrid.
@@ -51,7 +55,7 @@ Your Portkey pricing is a combination of four core elements:
 
 #### 1. Deployment Pattern
 
-Your deployment model is the biggest factor in determining your base price and cost structure. We offer three patterns to fit any enterprise architecture.
+Your deployment model is the biggest factor in determining your base price and cost structure. We offer two patterns to fit any enterprise architecture. A third pattern, fully airgapped, is documented below for existing customers but is no longer offered for new deployments.
 
 <Tabs>
   <Tab title="Portkey-Managed SaaS">
@@ -107,10 +111,12 @@ Your deployment model is the biggest factor in determining your base price and c
     </div>
   </Tab>
 
-  <Tab title="Airgapped Deployment">
+  <Tab title="Airgapped Deployment (Legacy)">
+    <AirgappedLegacy />
+
     <div style={{ display: 'flex', gap: '20px', alignItems: 'flex-start' }}>
       <div style={{ flex: '1' }}>
-        ### Fully Airgapped Deployment
+        ### Fully Airgapped Deployment (No Longer Offered)
         
         Complete control with all components (Data plane, Control plane, and AI Gateway) deployed within your infrastructure.
         
@@ -144,7 +150,7 @@ All enterprise deployment options include comprehensive security features such a
 
 #### 2. Production Gateway Deployments
 <Info>
-*Only relevant for Hybrid and Air-gapped deployments.*
+*Only relevant for Hybrid deployments (and existing Air-gapped deployments).*
 </Info>
 
 This lever allows you to align costs with the breadth of your implementation.
@@ -183,7 +189,7 @@ Unlimited dev/staging gateways are always included at no cost. You can also scal
 #### 3. Gateway Request Volume
 
 <Info>
-*This lever applies to SaaS and Hybrid deployments only. Airgapped deployments have unlimited, unmetered usage.*
+*This lever applies to SaaS and Hybrid deployments. Existing airgapped deployments have unlimited, unmetered usage.*
 </Info>
 
 <CardGroup cols={2}>
@@ -209,11 +215,11 @@ Unlimited dev/staging gateways are always included at no cost. You can also scal
     Pricing grows with your actual AI usage. As your LLM adoption increases, enjoy volume discounts and pay only for what you use.
   </Card>
   <Card
-    title="Unlimited for Airgapped"
+    title="Unlimited for Airgapped (Legacy)"
     icon="infinity"
     color="#7c3aed"
   >
-    On fully airgapped deployments, Portkey does <b>not</b> meter or charge for requests—run as many as you need with zero usage-based costs.
+    On existing fully airgapped deployments, Portkey does <b>not</b> meter or charge for requests—run as many as you need with zero usage-based costs. Airgapped is no longer offered for new deployments.
   </Card>
 </CardGroup>
 
@@ -282,7 +288,7 @@ Unlimited dev/staging gateways are always included at no cost. You can also scal
     - Measured monthly
     - Tiered pricing with volume discounts
     - Predictable with usage alerts and caps available
-    - Air-gapped deployments have NO usage-based fees
+    - Existing air-gapped deployments have NO usage-based fees
   </Accordion>
   
   <Accordion title="Can we start small and scale?">
@@ -290,7 +296,7 @@ Unlimited dev/staging gateways are always included at no cost. You can also scal
     - Single gateway deployment
     - Standard support
     - SaaS model for POC
-    Then migrate to Hybrid/Air-gapped with multiple gateways as they scale.
+    Then migrate to Hybrid with multiple gateways as they scale.
   </Accordion>
   
   <Accordion title="What's included in the platform fee?">

--- a/enterprise/security.mdx
+++ b/enterprise/security.mdx
@@ -1,16 +1,22 @@
 ---
 title: "Security"
-description: "Compare SaaS, Hybrid, and Airgapped security postures, data flows, and controls"
+description: "Compare SaaS and Hybrid security postures, data flows, and controls"
 mode: "center"
 noindex: "true"
 ---
 
-Portkey provides three enterprise deployment models with identical feature parity. This page explains the security posture, data flows, and shared-responsibility boundaries for each model—so InfoSec teams can assess risk quickly and choose confidently.
+import AirgappedLegacy from "/snippets/airgapped-legacy.mdx";
+
+Portkey provides two enterprise deployment models with identical feature parity—**SaaS Enterprise** and **Hybrid**. This page explains the security posture, data flows, and shared-responsibility boundaries for each model—so InfoSec teams can assess risk quickly and choose confidently.
+
+<AirgappedLegacy />
+
+Air-gapped columns are retained below for reference and for customers with an existing air-gapped deployment.
 
 
 ## Security Comparison (at a glance)
 
-| Control | SaaS Enterprise | Hybrid (Recommended) | Airgapped |
+| Control | SaaS Enterprise | Hybrid (Recommended) | Airgapped *(legacy — not offered)* |
 |:--|:--|:--|:--|
 | **Data residency** | Runtime in region of choice; customer data stored in region-specific shards (e.g., EU) | All data (requests, responses, logs) stays in your VPC/on‑prem; control-plane metrics region is customer’s choice | Fully offline; all data stays inside isolated network |
 | **Runtime data path** | Requests hit nearest regional edge gateway (e.g., EU only when EU is chosen) | Gateway runs inside your network; model calls stay local | Gateway and model calls run entirely offline |
@@ -28,7 +34,7 @@ Portkey provides three enterprise deployment models with identical feature parit
 
 - SaaS: Runtime traffic remains in the selected region. Minimal control‑plane metadata is stored centrally; customer data (logs/metrics) retained per policy (90/365 by default) with zero‑retention and PII scrubbing options.
 - Hybrid: Application data, prompts, responses, and logs stay entirely in your VPC/on‑prem. Metrics are always emitted to Portkey’s control plane (ClickHouse) and can be hosted in your region of choice. IP/URL redaction supported.
-- Air‑gapped: No outbound network calls for any purpose (including licensing and updates). All data remains inside the isolated environment.
+- Air‑gapped *(legacy — existing deployments only)*: No outbound network calls for any purpose (including licensing and updates). All data remains inside the isolated environment.
 
 ## Data flows (per model)
 
@@ -45,7 +51,7 @@ Portkey provides three enterprise deployment models with identical feature parit
 * IP and URL redaction supported; data‑plane↔control‑plane connectivity can be Internet or private tunnel/VPC peering.
 </Step>
 
-<Step title="Air‑gapped" icon="shield">
+<Step title="Air‑gapped (Legacy — Not Offered)" icon="shield">
 * Fully disconnected deployment—no outbound traffic required for licensing or updates.
 * Container images are delivered via private registry or offline media; updates applied offline on your schedule.
 </Step>
@@ -119,7 +125,7 @@ Portkey provides three enterprise deployment models with identical feature parit
 
 ## Shared responsibility
 
-| Area | SaaS Enterprise | Hybrid | Air‑gapped |
+| Area | SaaS Enterprise | Hybrid | Air‑gapped *(legacy — not offered)* |
 |:--|:--|:--|:--|
 | Data storage & residency | Portkey implements region pinning; you set retention | You own storage, residency, and lifecycle | You own storage, residency, offline lifecycle |
 | Metrics & telemetry | Portkey stores minimal metadata and metrics per policy | Metrics always sent to Portkey control plane; redaction supported | None |
@@ -128,7 +134,7 @@ Portkey provides three enterprise deployment models with identical feature parit
 | Patching & CVEs | Portkey SLAs | Portkey supplies signed images/SBOM; you apply updates | Same, offline process |
 | Backups & DR | Portkey managed | Customer managed (guidance provided) | Customer managed (offline) |
 
-## Why Hybrid is usually the right choice
+## Why Hybrid is the right choice
 
 <Steps>
 <Step title="Data stays put" icon="lock">

--- a/enterprise/tco-airgapped.mdx
+++ b/enterprise/tco-airgapped.mdx
@@ -1,7 +1,12 @@
 ---
 title: "Total Cost of Ownership (Airgapped)"
-description: "Infrastructure cost estimation for Full Private (Airgapped) deployment of Portkey AI Gateway."
+sidebarTitle: "TCO (Airgapped — Legacy)"
+description: "Infrastructure cost estimation for Full Private (Airgapped) deployment of Portkey AI Gateway. Legacy — no longer offered for new deployments."
 ---
+
+import AirgappedLegacy from "/snippets/airgapped-legacy.mdx";
+
+<AirgappedLegacy />
 
 In an Airgapped deployment, both the **Data Plane** and **Control Plane** run entirely within your cloud environment for complete data isolation.
 

--- a/integrations/libraries/openclaw.mdx
+++ b/integrations/libraries/openclaw.mdx
@@ -379,7 +379,7 @@ Developers use a simple config — all routing and reliability logic is handled 
   <Accordion title="Self-hosting">
     - **SaaS**: Everything on Portkey cloud
     - **Hybrid**: Gateway on your infra, control plane on Portkey
-    - **Air-gapped**: Everything on your infra
+    - **Air-gapped** *(legacy — existing deployments only)*: Everything on your infra
 
     In hybrid mode, the gateway has no runtime dependency on the control plane — routing continues even if the connection drops.
   </Accordion>

--- a/product/observability/cost-management.mdx
+++ b/product/observability/cost-management.mdx
@@ -26,7 +26,7 @@ For token-based budgets, Portkey tracks both input and output tokens across all 
 
 ## Deployment-Specific Pricing Management
 
-Portkey supports three deployment modes, each with different pricing update mechanisms:
+Portkey supports two deployment modes for new customers, each with different pricing update mechanisms. Air-gapped is documented below for existing deployments only.
 
 ### 1. SaaS Deployment (Portkey Cloud)
 
@@ -41,7 +41,11 @@ Portkey supports three deployment modes, each with different pricing update mech
 - **Maintenance**: Minimal - pricing JSON updates automatically from central control plane
 - **Manual Updates**: Only required when new pricing features are introduced
 
-### 3. Air-Gapped Deployment
+### 3. Air-Gapped Deployment (Legacy)
+
+<Note>
+Air-gapped deployment is no longer offered for new customers. This section applies to existing air-gapped deployments, which remain supported.
+</Note>
 
 - **Update Frequency**: Configurable — can be automatic (with outbound access) or manual
 - **Management**: Customer-managed pricing sources

--- a/product/product-feature-comparison.mdx
+++ b/product/product-feature-comparison.mdx
@@ -4,6 +4,8 @@ description: Comparing Portkey's Open-source version and Dev, Pro, Enterprise pl
 mode: "wide"
 ---
 
+import AirgappedLegacy from "/snippets/airgapped-legacy.mdx";
+
 Portkey has a generous free tier (10k requests/month) on our **Dev** plan — but, as you move to production-scale, you may benefit from Portkey's **Pro** or **Enterprise** plans.
 
 <CardGroup cols={4}>
@@ -38,7 +40,7 @@ Enterprise customers leverage Portkey to **observe**, **govern**, and **optimize
   <Card title="For Security & Compliance" icon="shield-check" iconType="solid" color="#0e7490" href="https://www.paloaltonetworks.com/ai-security/ai-gateway#:~:text=See%20Prisma%20AIRS%20AI%20Gateway%20in%20Action">
     ▪️ SOC2, ISO27001, GDPR, HIPAA
 
-    ▪️ VPC/Airgapped deployment
+    ▪️ VPC / Hybrid deployment
 
     ▪️ PII anonymization
 
@@ -106,7 +108,7 @@ Here's a detailed comparison of our plans to help you choose the right solution 
     - Organizations with compliance needs
     - Handling sensitive data
     - Custom infrastructure requirements
-    - Multiple deployment options (SaaS, Hybrid, Airgapped)
+    - Multiple deployment options (SaaS, Hybrid)
   </Card>
 </CardGroup>
 </Accordion>
@@ -231,10 +233,12 @@ Portkey offers a range of deployment options designed to meet the diverse securi
     </div>
   </Tab>
 
-  <Tab title="Airgapped Deployment">
+  <Tab title="Airgapped Deployment (Legacy)">
+    <AirgappedLegacy />
+
     <div style={{ display: 'flex', gap: '20px', alignItems: 'flex-start' }}>
       <div style={{ flex: '1' }}>
-        ### Fully Airgapped Deployment
+        ### Fully Airgapped Deployment (No Longer Offered)
         
         Complete control with all components (Data plane, Control plane, and AI Gateway) deployed within your infrastructure.
         
@@ -309,13 +313,13 @@ All enterprise deployment options include comprehensive security features such a
 
 <AccordionGroup>
   <Accordion title="What are the different deployment options available for Portkey Enterprise?">
-    Portkey Enterprise offers three deployment options:
+    Portkey Enterprise offers two deployment options:
     
     1. **Portkey-Managed SaaS**: A fully-managed solution where your data is hosted on Portkey's secure infrastructure with an isolated cluster exclusively for your organization.
     
     2. **Hybrid Deployment**: The AI Gateway and data plane run in your own environment while Portkey manages the control plane, ensuring all sensitive LLM data stays within your infrastructure.
     
-    3. **Fully Airgapped Deployment**: All components (Data plane, Control plane, and AI Gateway) are deployed within your infrastructure with zero data leaving your network.
+    A third option, **Fully Airgapped Deployment** (all components in your infrastructure with zero data leaving your network), is no longer offered for new deployments. Existing air-gapped deployments remain supported.
     
     Each option is designed to meet different security, compliance, and operational requirements. Our enterprise team can help you determine which option is best for your specific needs.
   </Accordion>

--- a/self-hosting/airgapped/model-pricing.mdx
+++ b/self-hosting/airgapped/model-pricing.mdx
@@ -1,8 +1,12 @@
 ---
 title: "Model Pricing for Air-Gapped Deployments"
 sidebarTitle: "Model Pricing (Air-Gapped)"
-description: "Configure model pricing and capabilities data for fully air-gapped Portkey deployments"
+description: "Configure model pricing and capabilities data for fully air-gapped Portkey deployments. Legacy — air-gapped is no longer offered for new deployments."
 ---
+
+import AirgappedLegacy from "/snippets/airgapped-legacy.mdx";
+
+<AirgappedLegacy />
 
 ## Requirements
 * [Helm chart](https://github.com/Portkey-AI/helm) `app-1.5.0+`

--- a/self-hosting/cache-behavior.mdx
+++ b/self-hosting/cache-behavior.mdx
@@ -10,7 +10,7 @@ The Gateway uses a local cache store (Redis or compatible) for two distinct purp
 2. **LLM response cache:** stores LLM request/response pairs for reuse across identical requests
 
 <Info>
-**Hybrid vs air-gapped:** In a hybrid deployment, the Control Plane is hosted by Portkey. In an air-gapped deployment, the Control Plane runs entirely within your own infrastructure.
+**Hybrid vs air-gapped:** In a hybrid deployment, the Control Plane is hosted by Portkey. In an air-gapped deployment, the Control Plane runs entirely within your own infrastructure. Air-gapped is no longer offered for new deployments; references to it apply to existing air-gapped customers.
 </Info>
 
 ---

--- a/snippets/airgapped-legacy.mdx
+++ b/snippets/airgapped-legacy.mdx
@@ -1,0 +1,5 @@
+<Warning>
+**Air-gapped deployment is no longer offered.** Portkey no longer provisions new fully air-gapped deployments. This content is retained for reference and for customers with an existing air-gapped deployment, which remains supported.
+
+[Contact us](https://www.paloaltonetworks.in/ai-security/ai-gateway#contact?utm_source=portkey&utm_medium=referral&utm_campaign=prisma_airs&utm_content=docs_footer) to discuss deployment options.
+</Warning>


### PR DESCRIPTION
Portkey no longer provisions new fully air-gapped deployments. Existing air-gapped customers remain supported, so the technical content is kept and relabeled rather than deleted.

- Add snippets/airgapped-legacy.mdx: a shared Warning used across all affected pages, linking to the Prisma AIRS contact form
- Sales-facing pages (pricing, poc, security, azure-deployment, tco-airgapped, product-feature-comparison): callout at top, air-gapped tabs/rows/columns relabeled "(Legacy)" / "No longer offered", and deployment-model counts reworded from three to two
- Technical docs (self-hosting/airgapped/model-pricing, cache-behavior, cost-management, openclaw): kept intact with legacy markers, since existing air-gapped deployments still need them
- docs.json: nav group renamed "Air-Gapped Deployments (Legacy)"

Changelogs and virtual_key_old/ are deliberately untouched — they are historical records. Version-requirement footnotes for air-gapped in jwt/sso/scim/secret-references/etc. are left as-is since they remain accurate for supported existing deployments.