### PR TITLE
fix(guardrails): correct forwardHeaders doc example to use external check

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -206,6 +206,7 @@
                       "product/guardrails/list-of-guardrail-checks",
                       "product/guardrails/embedding-guardrails",
                       "product/guardrails/creating-raw-guardrails-in-json",
+                      "product/guardrails/forwarding-headers",
                       "product/guardrails/pii-redaction",
                       "product/guardrails/guardrails-for-batches",
                       "integrations/guardrails/bring-your-own-guardrails"

--- a/integrations/guardrails/bring-your-own-guardrails.mdx
+++ b/integrations/guardrails/bring-your-own-guardrails.mdx
@@ -66,6 +66,7 @@ Your webhook should accept `POST` requests with the following structure:
 | :-- | :-- |
 | `Content-Type` | Always set to `application/json` |
 | Custom Headers | Any headers you configured in the Portkey UI |
+| Forwarded Headers | Client request headers configured via `parameters.forwardHeaders` on the check |
 
 #### Request Body
 
@@ -396,6 +397,24 @@ You can include additional context with each request using Portkey's metadata fe
 ```
 
 This metadata will be forwarded to your webhook in the `metadata` field. [Learn more about metadata](/product/observability/metadata).
+
+## Forwarding Client Headers
+
+You can forward specific client request headers to your webhook by adding `forwardHeaders` to the check's `parameters`. This is useful for passing trace IDs, session context, or tenant identifiers directly to your webhook endpoint.
+
+```json
+{
+  "id": "default.webhook",
+  "parameters": {
+    "webhookURL": "https://my-guardrail.example.com/check",
+    "forwardHeaders": ["x-session-id", "x-tenant-id", "traceparent"]
+  }
+}
+```
+
+Your webhook will receive these headers alongside `Content-Type` and any custom headers configured in the UI.
+
+<Card title="Forwarding Headers" href="/product/guardrails/forwarding-headers" />
 
 ## Important Implementation Notes
 

--- a/product/guardrails/creating-raw-guardrails-in-json.mdx
+++ b/product/guardrails/creating-raw-guardrails-in-json.mdx
@@ -63,6 +63,28 @@ In this example,
 * `on_success`: Used to pass custom `feedback`
 * `on_failure`: Used to pass custom `feedback`
 
+### Forwarding Client Headers
+
+You can forward specific client request headers to a guardrail provider by adding `forwardHeaders` inside the check's `parameters`:
+
+```JSON
+"before_request_hooks": [{
+    "type": "guardrail",
+    "id": "my_solid_guardrail",
+    "checks": [{
+      "id": "default.webhook",
+      "parameters": {
+        "webhookURL": "https://my-guardrail.example.com/check",
+        "forwardHeaders": ["x-session-id", "traceparent"]
+      }
+    }],
+    "deny": true,
+    "async": false
+}]
+```
+
+* `forwardHeaders`: Optional `string[]` of client headers to forward to this check's provider. If omitted, no client headers are forwarded. See [Forwarding Headers](/product/guardrails/forwarding-headers) for restricted headers and configuration details.
+
 
 import PrismaAirsCta from "/snippets/prisma-airs-cta.mdx";
 

--- a/product/guardrails/forwarding-headers.mdx
+++ b/product/guardrails/forwarding-headers.mdx
@@ -1,0 +1,64 @@
+---
+title: "Forwarding Headers"
+description: "Pass client request headers through to guardrail providers for trace correlation and session context."
+---
+
+Header forwarding passes specific client headers through to your guardrail providers. Use it for trace correlation, session-aware policy enforcement, or custom context your provider expects.
+
+Without forwarding configured, only `Content-Type` and the provider's authentication reach the guardrail endpoint. All other client headers stop at Portkey.
+
+---
+
+## Configuration
+
+Add `forwardHeaders` to any check's `parameters`. List the exact header names you want forwarded:
+
+```json
+{
+  "checks": [
+    {
+      "id": "default.regexMatch",
+      "parameters": {
+        "rule": "test",
+        "forwardHeaders": ["x-portkey-trace-id", "traceparent", "x-session-id"]
+      }
+    }
+  ]
+}
+```
+
+If `forwardHeaders` is absent or omitted, nothing is forwarded. Each check configures forwarding independently.
+
+Provider authentication headers always take precedence — forwarded headers cannot overwrite them.
+
+<Note>
+If you include `traceparent` in your list and the client sends `x-portkey-trace-id` but no `traceparent`, Portkey synthesizes a valid W3C traceparent automatically. If the client sends a valid `traceparent` directly, it passes through unchanged.
+</Note>
+
+---
+
+## Restricted Headers
+
+Portkey prevents forwarding headers that carry credentials or sensitive context. The following categories are blocked and rejected at save time:
+
+- **Credentials** — `authorization`, `x-api-key`, `ocp-apim-subscription-key`, `proxy-authorization`
+- **Session** — `cookie`
+- **Cloud metadata** — headers used by cloud IMDS endpoints (AWS, GCP)
+- **Internal routing** — all `x-portkey-*` headers except `x-portkey-trace-id` and `x-portkey-span-id`
+- **Hop-by-hop** — protocol headers like `connection`, `host`, `transfer-encoding`
+
+Header names must be valid per RFC 7230 — lowercase alphanumeric characters and hyphens only. Wildcards are not supported.
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Guardrails" href="/product/guardrails" />
+  <Card title="Bring Your Own Guardrails" href="/integrations/guardrails/bring-your-own-guardrails" />
+</CardGroup>
+
+
+import PrismaAirsCta from "/snippets/prisma-airs-cta.mdx";
+
+<PrismaAirsCta />

--- a/product/guardrails/forwarding-headers.mdx
+++ b/product/guardrails/forwarding-headers.mdx
@@ -11,15 +11,15 @@ Without forwarding configured, only `Content-Type` and the provider's authentica
 
 ## Configuration
 
-Add `forwardHeaders` to any check's `parameters`. List the exact header names you want forwarded:
+Add `forwardHeaders` to any external check's `parameters`. List the exact header names you want forwarded:
 
 ```json
 {
   "checks": [
     {
-      "id": "default.regexMatch",
+      "id": "default.webhook",
       "parameters": {
-        "rule": "test",
+        "webhookURL": "https://guardrails.example.com/check",
         "forwardHeaders": ["x-portkey-trace-id", "traceparent", "x-session-id"]
       }
     }


### PR DESCRIPTION
## Summary

- Fix the `forwardHeaders` config example: replace `default.regexMatch` with `default.webhook`
- `regexMatch` is a local check — it never makes an HTTP call, so `forwardHeaders` has no effect on it
- `webhook` actually calls an external URL and forwards the configured headers
- Update description to say "any external check" instead of "any check"