### PR TITLE
docs: add 403 troubleshooting note for non-Claude Bedrock models

### DIFF
--- a/integrations/libraries/claude-code-bedrock.mdx
+++ b/integrations/libraries/claude-code-bedrock.mdx
@@ -224,6 +224,28 @@ Or reinstall:
 curl -fsSL https://claude.ai/install.sh | bash
 ```
 
+### Error: `403 AccessDeniedException` with non-Claude Bedrock models
+
+**Cause:** Claude Code sends Anthropic-specific `cache_control` fields and `anthropic-beta` headers with every request. Models on Bedrock that are not Anthropic Claude (for example, `moonshotai.kimi-k2.5`) do not support these features and return a 403.
+
+**Fix:** Add the following to `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "DISABLE_PROMPT_CACHING": "1",
+    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1"
+  }
+}
+```
+
+- `DISABLE_PROMPT_CACHING=1` removes all `cache_control` fields from the request body.
+- `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` strips the `anthropic-beta` request headers.
+
+<Note>
+Claude Code will show a startup warning when `DISABLE_PROMPT_CACHING` is set. This is expected and does not affect functionality.
+</Note>
+
 ## Complete Example
 
 Full configuration with all features enabled:


### PR DESCRIPTION
Adds a new troubleshooting entry explaining that Claude Code's `cache_control` fields and `anthropic-beta` headers cause a 403 AccessDeniedException when routing to non-Anthropic models on Bedrock (e.g. moonshotai.kimi-k2.5). Documents the fix via DISABLE_PROMPT_CACHING and CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS.