### PR TITLE
docs: document azure-openai as supported semantic cache embedding pro…

### DIFF
--- a/product/ai-gateway/cache-simple-and-semantic.mdx
+++ b/product/ai-gateway/cache-simple-and-semantic.mdx
@@ -107,7 +107,7 @@ To enable semantic caching on a self-hosted Portkey gateway, configure the embed
     Set the following environment variables in your gateway environment for generating vector embeddings:
 
     ```bash
-    SEMANTIC_CACHE_EMBEDDING_PROVIDER=openai   # supported: openai, google, vertex-ai
+    SEMANTIC_CACHE_EMBEDDING_PROVIDER=openai   # supported: openai, azure-openai, google, vertex-ai
     SEMANTIC_CACHE_EMBEDDINGS_URL=https://api.openai.com/v1/embeddings
     SEMANTIC_CACHE_EMBEDDING_MODEL=text-embedding-3-small
     SEMANTIC_CACHE_EMBEDDING_API_KEY=<openai-api-key>
@@ -115,7 +115,20 @@ To enable semantic caching on a self-hosted Portkey gateway, configure the embed
     SEMANTIC_CACHE_EMBEDDING_DIMENSIONS=1536
     ```
 
-    `SEMANTIC_CACHE_EMBEDDING_PROVIDER` accepts `openai`, `google` (Gemini embeddings), or `vertex-ai` (Vertex AI embeddings). Set `SEMANTIC_CACHE_EMBEDDINGS_URL`, `SEMANTIC_CACHE_EMBEDDING_MODEL`, and `SEMANTIC_CACHE_EMBEDDING_DIMENSIONS` to match the chosen provider's embedding model.
+    `SEMANTIC_CACHE_EMBEDDING_PROVIDER` accepts `openai`, `azure-openai`, `google` (Gemini embeddings), or `vertex-ai` (Vertex AI embeddings). Set `SEMANTIC_CACHE_EMBEDDINGS_URL`, `SEMANTIC_CACHE_EMBEDDING_MODEL`, and `SEMANTIC_CACHE_EMBEDDING_DIMENSIONS` to match the chosen provider's embedding model.
+
+    For **Azure OpenAI**, set the variables as follows:
+
+    ```bash
+    SEMANTIC_CACHE_EMBEDDING_PROVIDER=azure-openai
+    SEMANTIC_CACHE_EMBEDDINGS_URL=https://YOUR-RESOURCE-NAME.openai.azure.com/openai/v1/embeddings
+    SEMANTIC_CACHE_EMBEDDING_MODEL=text-embedding-3-small
+    SEMANTIC_CACHE_EMBEDDING_API_KEY=<azure-openai-api-key>
+    SEMANTIC_CACHE_SIMILARITY_THRESHOLD=0.95
+    SEMANTIC_CACHE_EMBEDDING_DIMENSIONS=1536
+    ```
+
+    `SEMANTIC_CACHE_EMBEDDING_MODEL` must match your Azure deployment name. `SEMANTIC_CACHE_EMBEDDING_API_KEY` must be a plain Azure OpenAI API key; Managed Identity / Entra ID token auth is not supported for this call.
 
   </Step>
   <Step title="Configure the vector database">
@@ -159,7 +172,7 @@ To enable semantic caching on a self-hosted Portkey gateway, configure the embed
 </Steps>
 
 <Warning>
-  **Limitations:** - Embedding generation supports OpenAI, Google (Gemini), and
+  **Limitations:** -   Embedding generation supports OpenAI, Azure OpenAI, Google (Gemini), and
   Vertex AI embedding providers. - The LLM model used for generating responses
   must be OpenAI-compatible. - Each request must include at least one `user`
   message along with system messages. Requests with only system messages are


### PR DESCRIPTION
…vider

The gateway already handles azure-openai in the embedding switch, but it was undocumented. Adds the provider to the supported list, an Azure-specific env var example with endpoint URL format, and updates the Warning block to reflect all four supported providers.