### PR TITLE
docs: add create guardrail API curl example for Request Parameters Check

### DIFF
--- a/integrations/guardrails/request-parameters-check.mdx
+++ b/integrations/guardrails/request-parameters-check.mdx
@@ -42,6 +42,42 @@ Guardrail Actions let you orchestrate your guardrail's behaviour (deny, feedback
 | :--- | :--- | :--- | :--- |
 | Request Parameters Check | Allow/block tools, top-level request keys, and specific parameter values | `tools` (object), `params` (object) | `beforeRequestHook` |
 
+You can also create this guardrail directly via the API:
+
+```sh
+curl https://api.portkey.ai/v1/guardrails \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "x-portkey-api-key: $PORTKEY_API_KEY" \
+  -d '{
+    "name": "Request Parameters Guard",
+    "checks": [
+      {
+        "id": "default.requestParametersCheck",
+        "parameters": {
+          "tools": {
+            "allowedTypes": ["function"],
+            "blockedFunctionNames": ["executeShell", "dropTable"]
+          },
+          "params": {
+            "blockedKeys": ["logit_bias", "seed"],
+            "allowedKeys": ["model", "messages", "temperature", "max_tokens"],
+            "values": {
+              "model": { "allowedValues": ["gpt-4o", "gpt-4o-mini"] },
+              "stream": { "blockedValues": [true] },
+              "max_tokens": { "allowedValues": [256, 512, 1024, 2048] }
+            }
+          }
+        }
+      }
+    ],
+    "actions": {
+      "on_fail": "deny",
+      "on_success": "continue"
+    }
+  }'
+```
+
 ### 2. Add Guardrail ID to a Config and Make Your Request
 
 * When you save the Guardrail, you'll get an associated Guardrail ID - add this ID to the `input_guardrails` param in your Portkey Config


### PR DESCRIPTION
Adds a POST /guardrails curl snippet to the Request Parameters Check integration guide so users can create the guardrail directly via API.