### PR TITLE
fix: move AWS Bedrock STS session tags to v2.19.0 and add env flag

### DIFF
--- a/changelog/enterprise.mdx
+++ b/changelog/enterprise.mdx
@@ -62,6 +62,12 @@ Credit-based cost tracking is now available for the Meshy and Tripo3D 3D-generat
 
 [LLM Integrations](/integrations/llms)
 
+### AWS Bedrock STS Session Tags (Env-Gated)
+
+Per-request AWS session tags can now be passed through to Bedrock via STS, letting you attribute cost and audit trails per application while sharing a single assumed role. This feature is gated behind the `AWS_BEDROCK_STS_SESSION_TAGS_ENABLED` environment variable — set it to `true` on the gateway container to enable session tag passthrough.
+
+[Session Tags Documentation](/product/model-catalog/connect-bedrock-with-amazon-assumed-role#attribute-cost-and-usage-with-session-tags)
+
 ### Provider Updates
 
 - **Anthropic**: `output_config` is now forwarded for Messages requests
@@ -189,12 +195,6 @@ Anthropic Messages API requests can now be routed to models that use the OpenAI 
 New Lightning AI provider integration for chat completions.
 
 [LLM Integrations](/integrations/llms)
-
-### AWS Session Tags for Bedrock
-
-Per-request AWS session tags can now be passed through to Bedrock, letting you attribute cost and audit trails per application while sharing a single IAM role.
-
-[Session Tags Documentation](/product/model-catalog/connect-bedrock-with-amazon-assumed-role#attribute-cost-and-usage-with-session-tags)
 
 ### Akto Guardrails
 

--- a/product/model-catalog/connect-bedrock-with-amazon-assumed-role.mdx
+++ b/product/model-catalog/connect-bedrock-with-amazon-assumed-role.mdx
@@ -127,6 +127,10 @@ Once the role is created, copy the role ARN and paste it into the Bedrock integr
 
 You can attribute Bedrock cost and audit trails to individual applications, teams, or environments while sharing a single assumed role. Any metadata you send on a request is forwarded to AWS as [STS session tags](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html), so you can segregate spend in AWS Cost Explorer and CloudTrail without provisioning a separate IAM role per application.
 
+<Note>
+This feature requires the `AWS_BEDROCK_STS_SESSION_TAGS_ENABLED` environment variable to be set to `true` on the gateway container.
+</Note>
+
 Pass the tags using the `metadata` field (or the `x-portkey-metadata` header):
 
 ```sh


### PR DESCRIPTION
Summary
- Moves the AWS Bedrock STS Session Tags changelog entry from v2.16.0 to v2.19.0, where it was actually released (merge commit: chore: add aws bedrock sts tag passthrough upstream provider flagged via env by @naresh4dev in Portkey-AI/gateway-enterprise-node#1868)
- Adds the missing AWS_BEDROCK_STS_SESSION_TAGS_ENABLED environment variable documentation to both the changelog entry and the session tags guide page