### PR TITLE
docs: add proxy webhook guardrail documentation

### DIFF
--- a/changelog/enterprise.mdx
+++ b/changelog/enterprise.mdx
@@ -50,7 +50,7 @@ Set `SERVER_MODE=unified` to run the AI Gateway and MCP Gateway on a single port
 
 ### Webhook Guardrails for Proxy Requests
 
-The webhook guardrail can now run on proxy (`/v1/*`) requests via an opt-in `executeOnProxy` parameter, letting you block passthrough traffic based on a custom webhook check. Webhooks operate in deny-only mode on proxy routes (transforms are ignored) and require a JSON content type — non-JSON requests skip the check.
+The webhook guardrail can now run on proxy (`/v1/*`) requests via an opt-in `executeOnProxy` parameter, letting you block passthrough traffic based on a custom webhook check. Webhooks operate in deny-only mode on proxy routes (transforms are ignored) and require a JSON content type, as non-JSON requests skip the check.
 
 [Webhook Guardrails Documentation](/integrations/guardrails/bring-your-own-guardrails#webhook-guardrails-on-proxy-requests)
 

--- a/changelog/enterprise.mdx
+++ b/changelog/enterprise.mdx
@@ -50,9 +50,9 @@ Set `SERVER_MODE=unified` to run the AI Gateway and MCP Gateway on a single port
 
 ### Webhook Guardrails for Proxy Requests
 
-The webhook guardrail can now run on proxy (`/v1/*`) requests via an opt-in `executeOnProxy` parameter, letting you block passthrough traffic based on a custom webhook check.
+The webhook guardrail can now run on proxy (`/v1/*`) requests via an opt-in `executeOnProxy` parameter, letting you block passthrough traffic based on a custom webhook check. Webhooks operate in deny-only mode on proxy routes (transforms are ignored) and require a JSON content type — non-JSON requests skip the check.
 
-[Guardrails Documentation](/product/guardrails/list-of-guardrail-checks)
+[Webhook Guardrails Documentation](/integrations/guardrails/bring-your-own-guardrails#webhook-guardrails-on-proxy-requests)
 
 ### Provider Updates
 

--- a/integrations/guardrails/bring-your-own-guardrails.mdx
+++ b/integrations/guardrails/bring-your-own-guardrails.mdx
@@ -34,6 +34,7 @@ In the Guardrail configuration UI, you'll need to provide:
 | **Timeout** | Maximum wait time for webhook response | `number` (ms) |
 | **Fail on Error** | Treat a non-200 response or a timeout as a failed check | `boolean` |
 | **Forward Headers** | Client headers to forward to your webhook | `string[]` |
+| **Execute on Proxy** | Run this webhook on proxy (`/v1/*`) requests. When enabled, the webhook operates in deny-only mode — transforms are ignored. Default: `false` | `boolean` |
 
 #### Webhook URL
 
@@ -74,7 +75,8 @@ Skip the portal entirely and pass the webhook check inline in the request config
         "webhookURL": "https://guardrails.example.com/pre-check",
         "headers": { "Authorization": "Bearer WEBHOOK_TOKEN" },
         "timeout": 5000,
-        "failOnError": true
+        "failOnError": true,
+        "executeOnProxy": true
       }
     }]
   }],
@@ -221,7 +223,15 @@ Portkey sends comprehensive information about the AI request to your webhook:
   </ParamField>
   
   <ParamField body="provider" type="string">Portkey provider slug. Example: `openai`, `azure-openai`, etc.</ParamField>
-  <ParamField body="requestType" type="string">Type of request: `chatComplete`, `complete`, or `embed`</ParamField>
+  <ParamField body="requestType" type="string">Type of request: `chatComplete`, `complete`, `embed`, or `proxy`</ParamField>
+  <ParamField body="requestInfo" type="object">
+    HTTP metadata for the request. Present when the webhook runs on a proxy route.
+    <Expandable title="Properties">
+      <ParamField body="method" type="string">HTTP method (e.g., `POST`, `GET`)</ParamField>
+      <ParamField body="path" type="string">Request path (e.g., `/v1/moderations`)</ParamField>
+      <ParamField body="contentType" type="string|null">Content-Type header value (e.g., `application/json`)</ParamField>
+    </Expandable>
+  </ParamField>
 <ParamField body="metadata" type="object">Custom metadata passed with the request. Can come from: 1) the `x-portkey-metadata` header, 2) default API key settings, or 3) workspace defaults.</ParamField>
 <ParamField body="eventType" type="string">When the hook is triggered: `beforeRequestHook` or `afterRequestHook`</ParamField>
 </Expandable>
@@ -390,6 +400,10 @@ Return a verdict without modifying the request/response:
 
 Modify the user's request before it reaches the LLM provider:
 
+<Note>
+Request transformations are not applied for proxy requests. Webhook guardrails on proxy routes operate in deny-only mode.
+</Note>
+
 <Tabs>
 <Tab title="Example: Adding Content Policy">
 ```json
@@ -446,6 +460,10 @@ Modify the user's request before it reaches the LLM provider:
 ### Response Transformation
 
 Modify the LLM's response before it reaches the user:
+
+<Note>
+Response transformations are not applied for proxy requests. Webhook guardrails on proxy routes operate in deny-only mode.
+</Note>
 
 <Tabs>
 <Tab title="Example: Content Filtering">
@@ -544,6 +562,39 @@ You can forward specific client request headers to your webhook by adding `forwa
 Your webhook will receive these headers alongside `Content-Type` and any custom headers configured in the UI.
 
 <Card title="Forwarding Headers" href="/product/guardrails/forwarding-headers" />
+
+## Webhook Guardrails on Proxy Requests
+
+By default, webhook guardrails only run on standard routes (`/v1/chat/completions`, `/v1/embeddings`, etc.). To run a webhook guardrail on proxy (`/v1/*`) passthrough requests, set `executeOnProxy: true` on the webhook check.
+
+```json Inline config for proxy webhook
+{
+  "before_request_hooks": [{
+    "id": "proxy-content-check",
+    "type": "guardrail",
+    "deny": true,
+    "checks": [{
+      "id": "default.webhook",
+      "parameters": {
+        "webhookURL": "https://guardrails.example.com/proxy-check",
+        "executeOnProxy": true
+      }
+    }]
+  }]
+}
+```
+
+### How It Works
+
+- Your webhook receives the full JSON request body in `request.json`, along with `requestInfo` containing the HTTP method, path, and content type.
+- Both `before_request_hooks` and `after_request_hooks` are supported on proxy routes.
+- The webhook can allow or deny the request based on the payload content.
+
+### Limitations
+
+- **Deny-only mode**: `transformedData` returned by the webhook is ignored for proxy requests, since the webhook cannot know the upstream schema of an opaque passthrough body.
+- **JSON only**: Proxy requests with non-JSON content types (binary, FormData, etc.) skip the webhook entirely.
+- **All checks must opt in**: If a guardrail contains multiple checks, every check must be a `default.webhook` with `executeOnProxy: true`. Mixed guardrails (e.g., webhook + regex match) are skipped on proxy routes — split them into separate guardrails.
 
 ## Important Implementation Notes
 

--- a/integrations/guardrails/bring-your-own-guardrails.mdx
+++ b/integrations/guardrails/bring-your-own-guardrails.mdx
@@ -34,7 +34,7 @@ In the Guardrail configuration UI, you'll need to provide:
 | **Timeout** | Maximum wait time for webhook response | `number` (ms) |
 | **Fail on Error** | Treat a non-200 response or a timeout as a failed check | `boolean` |
 | **Forward Headers** | Client headers to forward to your webhook | `string[]` |
-| **Execute on Proxy** | Run this webhook on proxy (`/v1/*`) requests. When enabled, the webhook operates in deny-only mode — transforms are ignored. Default: `false` | `boolean` |
+| **Execute on Proxy** | Run webhooks on proxy requests in deny-only mode (transforms are ignored) | `boolean` |
 
 #### Webhook URL
 

--- a/product/guardrails/list-of-guardrail-checks.mdx
+++ b/product/guardrails/list-of-guardrail-checks.mdx
@@ -233,7 +233,7 @@ Basic deterministic guardrails are ideal for quick, hard-coded validations that 
 #### Extensibility
 | Guardrail Check | Description | Parameters | Supported On |
 | :--- | :--- | :--- | :--- |
-| **Webhook** | Makes a webhook request for custom guardrails. | `webhookURL`: string, `headers`: json | Input, Output |
+| **Webhook** | Makes a webhook request for custom guardrails. | `webhookURL`: string, `headers`: json, `executeOnProxy`: boolean | Input, Output |
 | **Log** | Makes a request to a log URL and always gives true as the verdict. | `logURL`: string, `headers`: json | Output only |
 
 


### PR DESCRIPTION
## Summary

- Documents the new `executeOnProxy` parameter for webhook guardrails, enabling webhook checks on proxy (`/v1/*`) passthrough requests
- Adds `requestInfo` field (`method`, `path`, `contentType`) to the webhook request body schema and `proxy` as a new `requestType` value
- Documents proxy-specific limitations: deny-only mode (transforms ignored), JSON-only content type requirement, and all-checks-must-opt-in constraint
- Updates the guardrail checks list and enterprise changelog entry

**Related Gateway PR:** https://github.com/Portkey-AI/gateway/pull/1920

## Changes

| File | What changed |
| :--- | :--- |
| `integrations/guardrails/bring-your-own-guardrails.mdx` | Added `Execute on Proxy` to parameters table, `executeOnProxy` in inline config example, `requestInfo` object in request body schema, `proxy` requestType, new "Webhook Guardrails on Proxy Requests" section, transform caveat notes |
| `product/guardrails/list-of-guardrail-checks.mdx` | Added `executeOnProxy: boolean` to Webhook row parameters |
| `changelog/enterprise.mdx` | Expanded v2.20.0 entry with deny-only and JSON-only details, updated link to new proxy-specific section |

## Test plan

- [x] Verified rendered output via Mintlify preview in PR