### PR TITLE
docs: add portkey tenant attributes to complete OTEL log export doc

### DIFF
--- a/product/enterprise-offering/otel/complete-logs.mdx
+++ b/product/enterprise-offering/otel/complete-logs.mdx
@@ -124,6 +124,16 @@ Logs are exported as OpenTelemetry spans with attributes following the [GenAI se
 | `otel.semconv.version` | `1.40.0` | Semantic convention version |
 | Custom attributes | Configurable | Additional attributes from `EXPERIMENTAL_GEN_AI_OTEL_RESOURCE_ATTRIBUTES` |
 
+### Portkey Tenant Attributes
+
+These attributes are set on all spans and identify the Portkey organisation, workspace, and user associated with the request:
+
+| Attribute | Source | Description |
+|-----------|--------|-------------|
+| `portkey.organisation.id` | Metrics | Organisation ID in Portkey |
+| `portkey.workspace.slug` | Metrics | Slug of the workspace that made the request |
+| `portkey.user.id` | Metrics | User ID or API key ID that initiated the request |
+
 ### Common Attributes
 
 These attributes are set on all spans (inference and embeddings):


### PR DESCRIPTION
Add missing portkey.* span attributes section that documents:
- portkey.organisation.id
- portkey.workspace.slug
- portkey.user.id

These are present in the implementation (buildPortkeyTenantSpanAttributes) but were not documented in the complete-logs.mdx page.